### PR TITLE
Migrate moment to dayjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,16 @@ import {
     AppRegistry,
     View
 } from 'react-native';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 import CalendarStrip from 'react-native-calendar-strip';
 
 class Example extends Component {
     let datesWhitelist = [{
-      start: moment(),
-      end: moment().add(3, 'days')  // total 4 days enabled
+      start: dayjs(),
+      end: dayjs().add(3, 'days')  // total 4 days enabled
     }];
-    let datesBlacklist = [ moment().add(1, 'days') ]; // 1 day disabled
+    let datesBlacklist = [ dayjs().add(1, 'days') ]; // 1 day disabled
 
     render() {
         return (
@@ -192,13 +192,13 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`numDaysInWeek`**  | Number of days shown in week. Applicable only when scrollable is false.                                                                                            | Number   | **`7`**    |
 | **`scrollable`**     | Dates are scrollable if true.                                                                                                                                      | Bool     | **`False`**|
 | **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true).                                                                        | Bool     | **`False`**|
-| **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.  | Any      |
-| **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.                                            | Any      |
-| **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` Moment date.                                                                      | Function |
-| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. Receives params `(start, end)` Moment dates.                                                             | Function |
-| **`onWeekScrollStart`**| Function to be used as a callback in `scrollable` mode when dates page starts gliding. Receives params `(start, end)` Moment dates.                              | Function |
-| **`onWeekScrollEnd`**| Function to be used as a callback in `scrollable` mode when dates page stops gliding. Receives params `(start, end)` Moment dates.                                 | Function |
-| **`onHeaderSelected`**| Function to be used as a callback when the header is selected. Receives param object `{weekStartDate, weekEndDate}` Moment dates.                                 | Function |
+| **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
+| **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |
+| **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` dayjs date.                                                                      | Function |
+| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. Receives params `(start, end)` dayjs dates.                                                             | Function |
+| **`onWeekScrollStart`**| Function to be used as a callback in `scrollable` mode when dates page starts gliding. Receives params `(start, end)` dayjs dates.                              | Function |
+| **`onWeekScrollEnd`**| Function to be used as a callback in `scrollable` mode when dates page stops gliding. Receives params `(start, end)` dayjs dates.                                 | Function |
+| **`onHeaderSelected`**| Function to be used as a callback when the header is selected. Receives param object `{weekStartDate, weekEndDate}` dayjs dates.                                 | Function |
 | **`headerText`**     | Text to use in the header. Use with `onWeekChanged` to receive the visible start & end dates.                                                                      | String  |
 | **`updateWeek`**     | Update the week view if other props change. If `false`, the week view won't change when other props change, but will still respond to left/right selectors.        | Bool     | **`True`** |
 | **`useIsoWeekday`**  | start week on ISO day of week (default true). If false, starts week on _startingDate_ parameter.                                                                   | Bool     | **`True`** |
@@ -215,12 +215,12 @@ AppRegistry.registerComponent('Example', () => Example);
 ```jsx
   datesWhitelist = [
     // single date (today)
-    moment(),
+    dayjs(),
 
     // date range
     {
-      start: (Date or moment Date),
-      end: (Date or moment Date)
+      start: (Date or dayjs Date),
+      end: (Date or dayjs Date)
     }
   ];
 
@@ -321,7 +321,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`calendarHeaderStyle`**      | Style for the header text of the calendar                                                                                                  | Any            |
 | **`calendarHeaderContainerStyle`** | Style for the header text wrapper of the calendar                                                                                      | Any            |
 | **`calendarHeaderPosition`**   | Position of the header text (above or below)                                                                                               | `above, below` | **`above`** |
-| **`calendarHeaderFormat`**     | Format for the header text of the calendar. For options, refer to [Moment documentation](http://momentjs.com/docs/#/displaying/format/)    | String         |
+| **`calendarHeaderFormat`**     | Format for the header text of the calendar. For options, refer to [dayjs documentation](https://day.js.org/docs/en/display/format)    | String         |
 | **`dateNameStyle`**            | Style for the name of the day on work days in dates strip                                                                                  | Any            |
 | **`dateNumberStyle`**          | Style for the number of the day on work days in dates strip.                                                                               | Any            |
 | **`dayContainerStyle`**        | Style for all day containers. RNCS scales the width & height responsively, so take that into account if overriding them.                   | Any            |
@@ -364,7 +364,7 @@ This prop may be passed an array of style objects or a callback which receives a
 
 ```jsx
   let customDatesStyles = [];
-  let startDate = moment();
+  let startDate = dayjs();
   for (let i=0; i<6; i++) {
     customDatesStyles.push({
         startDate: startDate.clone().add(i, 'days'), // Single date since no endDate provided
@@ -500,7 +500,7 @@ The `daySelectionAnimation` prop accepts an object in the following format:
 | ------------ | ---------------- | ------ |
 | **`locale`** | Locale for dates | Object |
 
-This prop is used for adding localization to react-native-calendar-strip component. The localization rules are the same as moments and can be found in [moments documentation](http://momentjs.com/docs/#/i18n/)
+This prop is used for adding localization to react-native-calendar-strip component. The localization rules follow dayjs and can be found in [dayjs documentation](https://day.js.org/docs/en/i18n/i18n)
 
 | `locale` Props | Description                                                 | Type   |
 | -------------- | ----------------------------------------------------------- | ------ |
@@ -511,18 +511,19 @@ This prop is used for adding localization to react-native-calendar-strip compone
 
 To properly make a release build, import the appropriate "Locale" module using the following steps.  Not importing the locale module will crash the release build (though the dev build will work).
 
-1- import momentJs module:
-> $ yarn add moment
+1- install dayjs with locales:
+> $ yarn add dayjs
 
 or
 
-> $ npm install moment
+> $ npm install dayjs
 
-2- Go to your index.js and import the specific "Locale" after the main moment import. Ex:
+2- Go to your index.js and import the specific locale before using CalendarStrip. Ex:
 ```
-import 'moment';
-import 'moment/locale/fr';  // language must match config
-import moment from 'moment-timezone';  // only if timezone is needed
+import dayjs from 'dayjs';
+import 'dayjs/locale/fr';  // language must match config
+import utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);  // only if timezone is needed
 ```
 
 The locale import must match the language specified in the locale config (example below).

--- a/__tests__/CalendarHeader.js
+++ b/__tests__/CalendarHeader.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import moment from "moment";
+import dayjs from "../src/dayjs";
 
 import CalendarHeader from "../src/CalendarHeader";
 
 configure({ adapter: new Adapter() });
 
-const today = moment();
+const today = dayjs();
 
 describe("CalendarHeader Component", () => {
   it("should render without issues", () => {

--- a/__tests__/Scroller.js
+++ b/__tests__/Scroller.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import moment from "moment";
+import dayjs from "../src/dayjs";
 
 import CalendarScroller from "../src/Scroller";
 
 configure({ adapter: new Adapter() });
 
-const today = moment();
+const today = dayjs();
 
 describe("CalendarScroller Component", () => {
   it("should render without issues", () => {

--- a/__tests__/WeekSelector.js
+++ b/__tests__/WeekSelector.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import moment from "moment";
+import dayjs from "../src/dayjs";
 
 import WeekSelector from "../src/WeekSelector";
 
 configure({ adapter: new Adapter() });
 
-const today = moment();
+const today = dayjs();
 
 describe("WeekSelector Component", () => {
   it("should render without issues", () => {

--- a/example/App.js
+++ b/example/App.js
@@ -7,13 +7,13 @@
 import React, { Component } from 'react';
 import { View, Text, Button } from 'react-native';
 import CalendarStrip from './CalendarStrip/CalendarStrip';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 export default class App extends Component<{}> {
   constructor(props) {
     super(props);
 
-    let startDate = moment(); // today
+    let startDate = dayjs(); // today
 
     // Create a week's worth of custom date styles and marked dates.
     let customDatesStyles = [];
@@ -71,13 +71,13 @@ export default class App extends Component<{}> {
   }
 
   setSelectedDateNextWeek = date => {
-    const selectedDate = moment(this.state.selectedDate).add(1, 'week');
+    const selectedDate = dayjs(this.state.selectedDate).add(1, 'week');
     const formattedDate = selectedDate.format('YYYY-MM-DD');
     this.setState({ selectedDate, formattedDate });
   }
 
   setSelectedDatePrevWeek = date => {
-    const selectedDate = moment(this.state.selectedDate).subtract(1, 'week');
+    const selectedDate = dayjs(this.state.selectedDate).subtract(1, 'week');
     const formattedDate = selectedDate.format('YYYY-MM-DD');
     this.setState({ selectedDate, formattedDate });
   }

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "expo": "~37.0.3",
-    "moment": "*",
+    "dayjs": "^1.11.9",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Component, ReactNode, ComponentProps, RefObject } from "react";
-import { Duration, Moment } from "moment";
+import { Dayjs } from "dayjs";
 import {
   StyleProp,
   ViewStyle,
@@ -30,7 +30,7 @@ interface IDaySelectionAnimationBackground {
 }
 
 interface IDayComponentProps {
-  date: Duration;
+  date: Dayjs;
   marking?: any;
   selected?: boolean;
   enabled: boolean;
@@ -54,7 +54,7 @@ interface IDayComponentProps {
   size: number;
   allowDayTextScaling?: boolean;
   markedDatesStyle?: TextStyle;
-  markedDates?: any[] | ((date: Moment) => void);
+  markedDates?: any[] | ((date: Dayjs) => void);
   upperCaseDays?: boolean;
 }
 
@@ -63,8 +63,8 @@ type TDaySelectionAnimation =
   | IDaySelectionAnimationBackground;
 
 type TDateRange = {
-  start: Moment;
-  end: Moment;
+  start: Dayjs;
+  end: Dayjs;
 };
 
 interface CalendarStripProps {
@@ -76,20 +76,20 @@ interface CalendarStripProps {
   scrollable?: boolean;
   scrollerPaging?: boolean;
   externalScrollView?: ComponentProps<typeof RecyclerListView>['externalScrollView'];
-  startingDate?: Moment | Date;
-  selectedDate?: Moment | Date;
-  onDateSelected?: ((date: Moment) => void);
-  onWeekChanged?: ((start: Moment, end: Moment) => void);
-  onWeekScrollStart?: ((start: Moment, end: Moment) => void);
-  onWeekScrollEnd?: ((start: Moment, end: Moment) => void);
-  onHeaderSelected?: ((dates: {weekStartDate: Moment, weekEndDate: Moment}) => void);
+  startingDate?: Dayjs | Date;
+  selectedDate?: Dayjs | Date;
+  onDateSelected?: ((date: Dayjs) => void);
+  onWeekChanged?: ((start: Dayjs, end: Dayjs) => void);
+  onWeekScrollStart?: ((start: Dayjs, end: Dayjs) => void);
+  onWeekScrollEnd?: ((start: Dayjs, end: Dayjs) => void);
+  onHeaderSelected?: ((dates: {weekStartDate: Dayjs, weekEndDate: Dayjs}) => void);
   updateWeek?: boolean;
   useIsoWeekday?: boolean;
-  minDate?: Moment | Date;
-  maxDate?: Moment | Date;
-  datesWhitelist?: TDateRange[] | ((date: Moment) => void);
-  datesBlacklist?: TDateRange[] | ((date: Moment) => void);
-  markedDates?: any[] | ((date: Moment) => void);
+  minDate?: Dayjs | Date;
+  maxDate?: Dayjs | Date;
+  datesWhitelist?: TDateRange[] | ((date: Dayjs) => void);
+  datesBlacklist?: TDateRange[] | ((date: Dayjs) => void);
+  markedDates?: any[] | ((date: Dayjs) => void);
   scrollToOnSetSelectedDate?: boolean;
 
   showMonth?: boolean;
@@ -122,7 +122,7 @@ interface CalendarStripProps {
   };
   daySelectionAnimation?: TDaySelectionAnimation;
 
-  customDatesStyles?: any[] | ((date: Moment) => void);
+  customDatesStyles?: any[] | ((date: Dayjs) => void);
 
   dayComponent?: (props: IDayComponentProps) => ReactNode;
 
@@ -154,8 +154,8 @@ interface CalendarStripProps {
 
 export default class ReactNativeCalendarStrip extends Component<CalendarStripProps> {
   getSelectedDate: () => undefined | Date | string;
-  setSelectedDate: (date: Moment | string) => void;
+  setSelectedDate: (date: Dayjs | string) => void;
   getNextWeek: () => void;
   getPreviousWeek: () => void;
-  updateWeekView: (date: Moment | string) => void;
+  updateWeekView: (date: Dayjs | string) => void;
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postinstall": "node-git-hooks"
   },
   "dependencies": {
-    "moment": ">=2.0.0",
+    "dayjs": "^1.11.9",
     "node-git-hooks": "^1.0.1",
     "prop-types": "^15.6.0",
     "recyclerlistview": "^3.0.0"

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import moment from "moment";
+import dayjs from "./dayjs";
 
 import { Text, View, Animated, Easing, LayoutAnimation, TouchableOpacity } from "react-native";
 import styles from "./Calendar.style.js";
@@ -250,7 +250,7 @@ class CalendarDay extends Component {
       if (markedDates.length === 0) {
         return {};
       }
-      return markedDates.find(md => moment(day).isSame(md.date, "day")) || {};
+      return markedDates.find(md => dayjs(day).isSame(md.date, "day")) || {};
     } else if (markedDates instanceof Function) {
       return markedDates(day) || {};
     }

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -6,7 +6,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { View, Animated, PixelRatio } from "react-native";
 
-import moment from "moment";
+import dayjs, { startOfISOWeek } from "./dayjs";
 
 import CalendarHeader from "./CalendarHeader";
 import CalendarDay from "./CalendarDay";
@@ -128,7 +128,7 @@ class CalendarStrip extends Component {
 
     if (props.locale) {
       if (props.locale.name && props.locale.config) {
-        moment.updateLocale(props.locale.name, props.locale.config);
+        dayjs.updateLocale(props.locale.name, props.locale.config);
       } else {
         throw new Error(
           "Locale prop is not in the correct format. \b Locale has to be in form of object, with params NAME and CONFIG!"
@@ -209,7 +209,7 @@ class CalendarStrip extends Component {
   // Returns true if the datetimes values are the same; false otherwise.
   compareDates = (date1, date2) => {
     if (date1 && date1.valueOf && date2 && date2.valueOf) {
-      return moment(date1).isSame(date2, "day");
+      return dayjs(date1).isSame(date2, "day");
     } else {
       return JSON.stringify(date1) === JSON.stringify(date2);
     }
@@ -217,7 +217,7 @@ class CalendarStrip extends Component {
 
   //Function that checks if the locale is passed to the component and sets it to the passed date
   setLocale = (date) => {
-    let _date = date && moment(date);
+    let _date = date && dayjs(date);
     if (_date) {
       _date.set({ hour: 12 }); // keep date the same regardless of timezone shifts
       if (this.props.locale) {
@@ -233,7 +233,7 @@ class CalendarStrip extends Component {
     } else {
       // Fallback when startingDate isn't provided. However selectedDate
       // may also be undefined, defaulting to today's date.
-      let date = this.setLocale(moment(this.props.selectedDate));
+      let date = this.setLocale(dayjs(this.props.selectedDate));
       return this.props.useIsoWeekday ? date.startOf("isoweek") : date;
     }
   };
@@ -273,7 +273,7 @@ class CalendarStrip extends Component {
     if (!this.props.updateWeek) {
       return originalStartDate;
     }
-    let startingDate = moment(newStartDate).startOf("day");
+    let startingDate = dayjs(newStartDate).startOf("day");
     let daysDiff = startingDate.diff(originalStartDate.startOf("day"), "days");
     if (daysDiff === 0) {
       return originalStartDate;
@@ -297,9 +297,9 @@ class CalendarStrip extends Component {
     }
 
     this.animations = [];
-    let startingDate = moment(date);
+    let startingDate = dayjs(date);
     startingDate = this.props.useIsoWeekday
-      ? startingDate.startOf("isoweek")
+      ? startOfISOWeek(startingDate)
       : startingDate;
     const days = this.createDays(startingDate);
     this.setState({ startingDate, ...days });
@@ -331,11 +331,11 @@ class CalendarStrip extends Component {
 
   // Set the selected date.  To clear the currently selected date, pass in 0.
   setSelectedDate = (date) => {
-    let mDate = moment(date);
+    let mDate = dayjs(date);
     this.onDateSelected(mDate);
     if (this.props.scrollToOnSetSelectedDate) {
       // Scroll to selected date, centered in the week
-      const scrolledDate = moment(mDate);
+      const scrolledDate = dayjs(mDate);
       scrolledDate.subtract(Math.floor(this.props.numDaysInWeek / 2), "days");
       this.scroller.scrollToDate(scrolledDate);
     }
@@ -485,7 +485,7 @@ class CalendarStrip extends Component {
       // Center start date in scroller.
       _startingDate = startingDate.clone().subtract(numDays / 2, "days");
       if (minDate && _startingDate.isBefore(minDate, "day")) {
-        _startingDate = moment(minDate);
+        _startingDate = dayjs(minDate);
       }
     }
 

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -13,7 +13,7 @@ import {
   DataProvider,
   LayoutProvider,
 } from "recyclerlistview";
-import moment from "moment";
+import dayjs from "./dayjs";
 
 export default class CalendarScroller extends Component {
   static propTypes = {
@@ -139,7 +139,7 @@ export default class CalendarScroller extends Component {
     //   Math.round(this.state.numVisibleItems / 2) - 1,
     //   "days"
     // );
-    let targetDate = moment(date).isoWeekday(1);
+    let targetDate = dayjs(date).isoWeekday(1);
     const { minDate, maxDate } = this.props;
 
     // Falls back to min or max date when the given date exceeds the available dates
@@ -183,7 +183,7 @@ export default class CalendarScroller extends Component {
     const data = [];
     let _newStartDate = newStartDate;
     if (minDate && newStartDate.isBefore(minDate, "day")) {
-      _newStartDate = moment(minDate);
+      _newStartDate = dayjs(minDate);
     }
     for (let i = 0; i < this.state.numDays; i++) {
       let date = _newStartDate.clone().add(i, "days");
@@ -230,14 +230,14 @@ export default class CalendarScroller extends Component {
     const visibleStartIndex = all[0];
     const visibleStartDate = data[visibleStartIndex]
       ? data[visibleStartIndex].date
-      : moment();
+      : dayjs();
     const visibleEndIndex = Math.min(
       visibleStartIndex + numVisibleItems - 1,
       data.length - 1
     );
     const visibleEndDate = data[visibleEndIndex]
       ? data[visibleEndIndex].date
-      : moment();
+      : dayjs();
 
     const { updateMonthYear, onWeekChanged } = this.props;
 
@@ -316,12 +316,12 @@ export default class CalendarScroller extends Component {
       ? visibleStartDate
       : data[visibleStartIndex]
       ? data[visibleStartIndex].date
-      : moment();
+      : dayjs();
     const prevEndDate = visibleEndDate
       ? visibleEndDate
       : data[visibleEndIndex]
       ? data[visibleEndIndex].date
-      : moment();
+      : dayjs();
 
     this.setState({
       prevStartDate,

--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Image, TouchableOpacity } from "react-native";
 
-import moment from "moment";
+import dayjs from "./dayjs";
 
 import styles from "./Calendar.style.js";
 
@@ -46,7 +46,7 @@ class WeekSelector extends Component {
 
   isEnabled(controlDate, weekStartDate, weekEndDate) {
     if (controlDate) {
-      return !moment(controlDate).isBetween(
+      return !dayjs(controlDate).isBetween(
         weekStartDate,
         weekEndDate,
         "day",

--- a/src/dayjs.js
+++ b/src/dayjs.js
@@ -1,0 +1,25 @@
+import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
+import updateLocale from 'dayjs/plugin/updateLocale';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import weekday from 'dayjs/plugin/weekday';
+
+dayjs.extend(isBetween);
+dayjs.extend(updateLocale);
+dayjs.extend(advancedFormat);
+dayjs.extend(weekday);
+
+// Plugin to provide Moment-like isoWeekday functionality
+const isoWeekday = (option, DayjsClass) => {
+  DayjsClass.prototype.isoWeekday = function(input) {
+    const current = this.day() === 0 ? 7 : this.day();
+    if (input == null) return current;
+    return this.add(input - current, 'day');
+  };
+};
+
+dayjs.extend(isoWeekday);
+
+export const startOfISOWeek = (date) => date.isoWeekday(1).startOf('day');
+
+export default dayjs;


### PR DESCRIPTION
## Summary
- migrate date handling from moment to dayjs
- add dayjs wrapper with isoWeekday helper
- update calendar components and example to use dayjs
- fix type declarations and tests
- update documentation and package files

## Testing
- `npm test` *(fails: ESLint couldn't find a config file)*