### PR TITLE
Refactor scroll buffer logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`numDaysInWeek`**  | Number of days shown in week. Applicable only when scrollable is false.                                                                                            | Number   | **`7`**    |
 | **`scrollable`**     | Dates are scrollable if true.                                                                                                                                      | Bool     | **`False`**|
 | **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true).                                                                        | Bool     | **`False`**|
+| **`weekBuffer`**     | Number of weeks kept in memory when scrollable. The visible week plus this many weeks before and after will be rendered. Works with custom `numDaysInWeek`. | Number | **`3`** |
 | **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
 | **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |
 | **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` dayjs date.                                                                      | Function |

--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { configure, shallow } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import dayjs from "../src/dayjs";
+
+import CalendarStrip from "../src/CalendarStrip";
+
+configure({ adapter: new Adapter() });
+
+describe("CalendarStrip getMaxSimultaneousDays", () => {
+  it("returns week buffer default when no range provided", () => {
+    const component = shallow(<CalendarStrip />);
+    const instance = component.instance();
+    expect(instance.getMaxSimultaneousDays()).toBe(21); // 3 weeks
+  });
+
+  it("returns diff when range is smaller", () => {
+    const min = dayjs("2025-01-01");
+    const max = dayjs("2025-01-10");
+    const component = shallow(<CalendarStrip minDate={min} maxDate={max} />);
+    const instance = component.instance();
+    expect(instance.getMaxSimultaneousDays()).toBe(10);
+  });
+
+  it("returns buffer when range is larger", () => {
+    const min = dayjs("2010-01-01");
+    const max = dayjs("2030-12-31");
+    const component = shallow(<CalendarStrip minDate={min} maxDate={max} />);
+    const instance = component.instance();
+    expect(instance.getMaxSimultaneousDays()).toBe(21);
+  });
+
+  it("respects custom weekBuffer", () => {
+    const component = shallow(<CalendarStrip weekBuffer={5} />);
+    const instance = component.instance();
+    expect(instance.getMaxSimultaneousDays()).toBe(35);
+  });
+
+  it("uses numDaysInWeek for multi-week views", () => {
+    const component = shallow(
+      <CalendarStrip numDaysInWeek={14} weekBuffer={2} />
+    );
+    const instance = component.instance();
+    expect(instance.getMaxSimultaneousDays()).toBe(28);
+  });
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ interface CalendarStripProps {
   scrollerPaging?: boolean;
   externalScrollView?: ComponentProps<typeof RecyclerListView>['externalScrollView'];
   startingDate?: Dayjs | Date;
+  weekBuffer?: number;
   selectedDate?: Dayjs | Date;
   onDateSelected?: ((date: Dayjs) => void);
   onWeekChanged?: ((start: Dayjs, end: Dayjs) => void);

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -257,17 +257,10 @@ export default class CalendarScroller extends Component {
       data.push({ date });
     }
     
-    console.log('생성된 data.length:', data.length);
-    console.log('data 범위:', data.length > 0 ? `${data[0].date.format('YYYY-MM-DD')} ~ ${data[data.length-1].date.format('YYYY-MM-DD')}` : 'empty');
-    
     // Prevent reducing range when the minDate - maxDate range is small.
     if (data.length < this.props.maxSimultaneousDays) {
-      console.log('❌ updateDays 중단: data.length < maxSimultaneousDays');
-      console.log(`data.length(${data.length}) < maxSimultaneousDays(${this.props.maxSimultaneousDays})`);
       return;
     }
-    
-    console.log('✅ updateDays 계속 진행');
     // Scroll to previous date
     for (let i = 0; i < data.length; i++) {
       if (data[i].date.isSame(prevVisStart, "day")) {
@@ -391,6 +384,21 @@ export default class CalendarScroller extends Component {
       const visStart = visibleStartDate && visibleStartDate.clone();
       const visEnd = visibleEndDate && visibleEndDate.clone();
       updateMonthYear && updateMonthYear(visStart, visEnd);
+    }
+
+    // Shift the buffered range when scrolling past either end
+    if (visibleStartIndex === 0) {
+      this.shiftDaysBackward(visibleStartDate);
+    } else {
+      const minEndOffset = numDays - numVisibleItems;
+      if (minEndOffset > numVisibleItems) {
+        for (let a of all) {
+          if (a > minEndOffset) {
+            this.shiftDaysForward(visibleStartDate);
+            break;
+          }
+        }
+      }
     }
 
     this.setState({


### PR DESCRIPTION
## Summary
- support a small scrolling buffer via new `weekBuffer` prop
- default to only rendering the previous, current, and next week
- update unit tests for new default behavior
- document the `weekBuffer` prop and add TypeScript definition
- restore dynamic week shifting so new weeks load beyond the buffer

## Testing
- `npm test` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_688485b9535483228f29dc44f97b96c0