### PR TITLE
Update CalendarStrip isSelected -> isActive

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -342,7 +342,7 @@ const CalendarStrip = ({
               : day.date.format('ddd')
             }
             isToday={day.isToday}
-            isSelected={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
+            isActive={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
             isWeekend={day.dayOfWeek === 0 || day.dayOfWeek === 6}
             isCurrentMonth={day.isCurrentMonth}
             onDateSelected={() => handleDateSelection(day.date)}
@@ -432,7 +432,7 @@ const CalendarStrip = ({
                   : day.date.format('ddd')
                 }
                 isToday={day.isToday}
-                isSelected={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
+                isActive={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
                 isWeekend={day.dayOfWeek === 0 || day.dayOfWeek === 6}
                 isCurrentMonth={day.isCurrentMonth}
                 onDateSelected={() => handleDateSelection(day.date)}


### PR DESCRIPTION
## Summary
- rename prop `isSelected` to `isActive` when rendering `CalendarDateItem`

## Testing
- `npm run test` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_b_688642c1e83483229012ce9fa6aaf1a9