### PR TITLE
Remove unused fast-safe-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "dayjs": "^1.11.9",
-    "fast-safe-stringify": "^2.1.1",
     "node-git-hooks": "^1.0.1",
     "prop-types": "^15.6.0",
     "react-native-pager-view": "^6.8.1"


### PR DESCRIPTION
## Summary
- remove `fast-safe-stringify` dependency from `package.json`

## Testing
- `npm test` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_b_688642c0821c83229e46193619804740