### PR TITLE
Remove unused month prop

### DIFF
--- a/src/components/CalendarDateItem.js
+++ b/src/components/CalendarDateItem.js
@@ -8,11 +8,10 @@ import dayjs from 'dayjs';
  * Renders a single date item in the calendar strip
  * Optimized with React.memo to prevent unnecessary re-renders
  */
-const CalendarDateItem = memo(({
+const CalendarDateItem = memo(({ 
   date,
   dateNumber,
   dayName,
-  month,
   isActive,
   isToday,
   isWeekend,
@@ -184,7 +183,6 @@ CalendarDateItem.propTypes = {
   date: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.object]).isRequired,
   dateNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   dayName: PropTypes.string.isRequired,
-  month: PropTypes.number.isRequired,
   isActive: PropTypes.bool,
   isToday: PropTypes.bool,
   isWeekend: PropTypes.bool,


### PR DESCRIPTION
## Summary
- clean up CalendarDateItem props
- drop `month` prop from prop type definition

## Testing
- `npm test` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_688642c0750883229c7954f95ff721b4