### PR TITLE
Add CalendarController and expose WeekSelector/Scroller

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -387,3 +387,30 @@ export interface CalendarStripMethods {
 declare function CalendarStrip(props: CalendarStripProps): JSX.Element;
 
 export default CalendarStrip;
+
+export class CalendarController {
+  constructor(options?: {
+    initialDate?: Date;
+    useIsoWeekday?: boolean;
+    numDaysInWeek?: number;
+    minDate?: Date;
+    maxDate?: Date;
+    is2WeekView?: boolean;
+  });
+  addListener(listener: Function): () => void;
+  jumpToDate(date: Date): void;
+  goToNextWeek(): void;
+  goToPreviousWeek(): void;
+  getCurrentWeek(): CalendarWeek | null;
+  getCurrentWeekIndex(): number;
+  getWeeks(): CalendarWeek[];
+  getSelectedDateNative(): Date | null;
+  getSelectedDate(): Dayjs;
+  selectDate(date: Date): void;
+  findWeekIndexByDate(date: Dayjs | Date | string): number;
+}
+
+export function WeekSelector(props: any): JSX.Element;
+export function Scroller(props: any): JSX.Element;
+
+export { CalendarStrip };

--- a/index.js
+++ b/index.js
@@ -1,2 +1,10 @@
-const Calendar = require("./src/components/CalendarStrip");
-module.exports = Calendar;
+const CalendarStrip = require('./src/components/CalendarStrip');
+const CalendarController = require('./src/controllers/CalendarController');
+const WeekSelector = require('./src/WeekSelector');
+const Scroller = require('./src/Scroller');
+
+module.exports = CalendarStrip;
+module.exports.CalendarStrip = CalendarStrip;
+module.exports.CalendarController = CalendarController;
+module.exports.WeekSelector = WeekSelector;
+module.exports.Scroller = Scroller;

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -1,0 +1,1 @@
+export { default } from './components/CalendarStrip';

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, ScrollView } from 'react-native';
+import PropTypes from 'prop-types';
+
+const Scroller = ({ children, style, ...rest }) => (
+  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={style} {...rest}>
+    {children}
+  </ScrollView>
+);
+
+Scroller.propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.any,
+  minDate: PropTypes.any,
+  maxDate: PropTypes.any,
+};
+
+export default Scroller;

--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { TouchableOpacity, Image } from 'react-native';
+import PropTypes from 'prop-types';
+
+const WeekSelector = ({ onPress, icon, size = 24, children }) => (
+  <TouchableOpacity onPress={onPress}>
+    {children || (icon ? <Image source={icon} style={{ width: size, height: size }} /> : null)}
+  </TouchableOpacity>
+);
+
+WeekSelector.propTypes = {
+  onPress: PropTypes.func,
+  icon: PropTypes.any,
+  size: PropTypes.number,
+  children: PropTypes.node,
+  controlDate: PropTypes.any,
+  weekStartDate: PropTypes.any,
+  weekEndDate: PropTypes.any,
+};
+
+export default WeekSelector;

--- a/src/controllers/CalendarController.js
+++ b/src/controllers/CalendarController.js
@@ -1,0 +1,143 @@
+import dayjs from '../dayjs';
+
+class CalendarController {
+  constructor(options = {}) {
+    this._options = {
+      initialDate: options.initialDate || new Date(),
+      useIsoWeekday: options.useIsoWeekday || false,
+      numDaysInWeek: options.numDaysInWeek || 7,
+      minDate: options.minDate ? dayjs(options.minDate) : undefined,
+      maxDate: options.maxDate ? dayjs(options.maxDate) : undefined,
+      is2WeekView: options.is2WeekView || false,
+    };
+
+    this._listeners = new Set();
+    this._weeks = [];
+    this._selectedDate = dayjs(this._options.initialDate);
+    this._currentWeekIndex = 0;
+
+    this._initialize();
+  }
+
+  _initialize() {
+    this._prepareWeeks(this._selectedDate, 3);
+  }
+
+  _getWeekStart(date) {
+    const d = dayjs(date);
+    return this._options.useIsoWeekday ? d.startOf('isoWeek') : d.startOf('week');
+  }
+
+  _generateDay(dateInput) {
+    const d = dayjs(dateInput);
+    if (!d.isValid()) return null;
+    const today = dayjs();
+    return {
+      date: d.toDate(),
+      dateString: d.format('YYYY-MM-DD'),
+      dayOfWeek: d.day(),
+      dayOfMonth: d.date(),
+      month: d.month(),
+      year: d.year(),
+      isToday: d.isSame(today, 'day'),
+      isCurrentMonth: d.month() === today.month() && d.year() === today.year(),
+    };
+  }
+
+  _generateWeek(startDate) {
+    const start = dayjs(startDate);
+    const days = [];
+    for (let i = 0; i < this._options.numDaysInWeek; i++) {
+      const day = this._generateDay(start.add(i, 'day'));
+      if (day) days.push(day);
+    }
+    return {
+      id: start.format('YYYY-MM-DD'),
+      startDate: start,
+      endDate: start.add(this._options.numDaysInWeek - 1, 'day'),
+      days,
+    };
+  }
+
+  _prepareWeeks(centerDate, count = 3) {
+    this._weeks = [];
+    const centerStart = this._getWeekStart(centerDate);
+    const half = Math.floor(count / 2);
+    for (let i = -half; i <= half; i++) {
+      const weekStart = centerStart.add(i * this._options.numDaysInWeek, 'day');
+      this._weeks.push(this._generateWeek(weekStart));
+    }
+    this._currentWeekIndex = half;
+  }
+
+  addListener(listener) {
+    if (typeof listener === 'function') {
+      this._listeners.add(listener);
+      return () => this._listeners.delete(listener);
+    }
+    return () => {};
+  }
+
+  _notify() {
+    this._listeners.forEach((fn) => fn(this));
+  }
+
+  selectDate(date) {
+    this._selectedDate = dayjs(date);
+    this._notify();
+  }
+
+  jumpToDate(date) {
+    this.selectDate(date);
+    this._prepareWeeks(dayjs(date), this._weeks.length || 3);
+  }
+
+  goToNextWeek() {
+    this._currentWeekIndex += 1;
+    const lastWeek = this._weeks[this._weeks.length - 1];
+    const nextStart = this._getWeekStart(lastWeek.startDate).add(this._options.numDaysInWeek, 'day');
+    this._weeks.push(this._generateWeek(nextStart));
+    this._notify();
+  }
+
+  goToPreviousWeek() {
+    this._currentWeekIndex -= 1;
+    const firstWeek = this._weeks[0];
+    const prevStart = this._getWeekStart(firstWeek.startDate).subtract(this._options.numDaysInWeek, 'day');
+    this._weeks.unshift(this._generateWeek(prevStart));
+    this._notify();
+  }
+
+  findWeekIndexByDate(date) {
+    const target = dayjs(date);
+    for (let i = 0; i < this._weeks.length; i++) {
+      const w = this._weeks[i];
+      if (target.isSameOrAfter(w.startDate, 'day') && target.isSameOrBefore(w.endDate, 'day')) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  getCurrentWeek() {
+    return this._weeks[this._currentWeekIndex] || null;
+  }
+
+  getCurrentWeekIndex() {
+    return this._currentWeekIndex;
+  }
+
+  getWeeks() {
+    return this._weeks;
+  }
+
+  getSelectedDate() {
+    return this._selectedDate;
+  }
+
+  getSelectedDateNative() {
+    return this._selectedDate ? this._selectedDate.toDate() : null;
+  }
+}
+
+export default CalendarController;


### PR DESCRIPTION
## Summary
- implement CalendarController per docs
- add basic WeekSelector and Scroller components
- expose new modules via index.js and typings

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_688642c0ad108322b25b3231574ac067