### PR TITLE
Account for right selector width

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -169,6 +169,7 @@ const CalendarStrip = ({
   });
   const [viewWidth, setViewWidth] = useState(Dimensions.get('window').width);
   const [leftWidth, setLeftWidth] = useState(0);
+  const [rightWidth, setRightWidth] = useState(0);
 
   // Handle selectedDate changes
   useEffect(() => {
@@ -374,7 +375,11 @@ const CalendarStrip = ({
     setLeftWidth(e.nativeEvent.layout.width);
   }, []);
 
-  const contentWidth = Math.max(viewWidth - leftWidth, 0);
+  const onRightLayout = useCallback(e => {
+    setRightWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const contentWidth = Math.max(viewWidth - leftWidth - rightWidth, 0);
 
   // Render week
   const renderWeek = useCallback(({ item: week }) => {
@@ -505,7 +510,7 @@ const CalendarStrip = ({
           </View>
         )}
         
-        <View>{rightSelector}</View>
+        <View onLayout={onRightLayout}>{rightSelector}</View>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- keep track of right selector width in CalendarStrip
- subtract right width from week width
- measure right selector with `onRightLayout`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_688645b25f488322ac40128cbdffd789