### PR TITLE
Enforce min/max week limits

### DIFF
--- a/__tests__/CalendarController.js
+++ b/__tests__/CalendarController.js
@@ -171,8 +171,34 @@ describe('CalendarController', () => {
       const initialIndex = controller.getCurrentWeekIndex();
       controller.goToNextWeek();
       const newIndex = controller.getCurrentWeekIndex();
-      
+
       expect(newIndex).toBe(initialIndex + 1);
+    });
+
+    it('should stop at maxDate when navigating forward', () => {
+      controller = new CalendarController({
+        initialDate: new Date(2025, 0, 7),
+        maxDate: new Date(2025, 0, 10)
+      });
+
+      const initialIndex = controller.getCurrentWeekIndex();
+      controller.goToNextWeek();
+      const newIndex = controller.getCurrentWeekIndex();
+
+      expect(newIndex).toBe(initialIndex);
+    });
+
+    it('should stop at minDate when navigating backward', () => {
+      controller = new CalendarController({
+        initialDate: new Date(2025, 0, 2),
+        minDate: new Date(2025, 0, 1)
+      });
+
+      const initialIndex = controller.getCurrentWeekIndex();
+      controller.goToPreviousWeek();
+      const newIndex = controller.getCurrentWeekIndex();
+
+      expect(newIndex).toBe(initialIndex);
     });
   });
 });

--- a/src/controllers/CalendarController.js
+++ b/src/controllers/CalendarController.js
@@ -93,17 +93,24 @@ class CalendarController {
   }
 
   goToNextWeek() {
-    this._currentWeekIndex += 1;
     const lastWeek = this._weeks[this._weeks.length - 1];
     const nextStart = this._getWeekStart(lastWeek.startDate).add(this._options.numDaysInWeek, 'day');
+    if (this._options.maxDate && nextStart.isAfter(this._options.maxDate, 'day')) {
+      return;
+    }
+    this._currentWeekIndex += 1;
     this._weeks.push(this._generateWeek(nextStart));
     this._notify();
   }
 
   goToPreviousWeek() {
-    this._currentWeekIndex -= 1;
     const firstWeek = this._weeks[0];
     const prevStart = this._getWeekStart(firstWeek.startDate).subtract(this._options.numDaysInWeek, 'day');
+    const prevEnd = prevStart.add(this._options.numDaysInWeek - 1, 'day');
+    if (this._options.minDate && prevEnd.isBefore(this._options.minDate, 'day')) {
+      return;
+    }
+    this._currentWeekIndex -= 1;
     this._weeks.unshift(this._generateWeek(prevStart));
     this._notify();
   }


### PR DESCRIPTION
## Summary
- prevent navigating to weeks beyond minDate or maxDate
- test calendar controller navigation respects minDate/maxDate boundaries

## Testing
- `npm test` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886459cca2883228d0a76365d7b0d53