### PR TITLE
Fix updateMonthYear callback args

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -73,7 +73,7 @@ yarn add atflee_react-native-calendar-strip
 | `onDateSelected` | `Function` | `undefined` | 날짜 선택 시 호출되는 콜백: `(date) => void` |
 | `onWeekChanged` | `Function` | `undefined` | 주 변경 시 호출되는 콜백: `(start, end) => void` |
 | `onHeaderSelected` | `Function` | `undefined` | 헤더 선택 시 호출되는 콜백: `() => void` |
-| `updateMonthYear` | `Function` | `undefined` | 표시되는 월/연도 업데이트 시 호출되는 콜백: `(month, year) => void` |
+| `updateMonthYear` | `Function` | `undefined` | 표시되는 월/연도 업데이트 시 호출되는 콜백: `(month, year) => void` (`month`: `MM`, `year`: `YYYY`) |
 
 ##### 커스텀 컴포넌트
 

--- a/__tests__/CalendarStripV2.js
+++ b/__tests__/CalendarStripV2.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
 import dayjs from 'dayjs';
 import CalendarStrip from '../src/components/CalendarStrip';
 import CalendarController from '../src/controllers/CalendarController';
@@ -107,6 +108,26 @@ describe('CalendarStrip Component', () => {
       );
       expect(getByTestId('calendar-strip')).toBeTruthy();
     });
+  });
+
+  it('should call updateMonthYear with formatted values', () => {
+    const updateMock = jest.fn();
+    const startDate = new Date(2024, 10, 15); // 15 Nov 2024
+
+    const { UNSAFE_getByType } = render(
+      <CalendarStrip
+        {...getBaseProps()}
+        startingDate={startDate}
+        updateMonthYear={updateMock}
+      />
+    );
+
+    const flatList = UNSAFE_getByType(FlatList);
+    const cb = flatList.props.viewabilityConfigCallbackPairs[0].onViewableItemsChanged;
+    cb({ viewableItems: [{ index: 1 }] });
+
+    const middleDate = dayjs(startDate).startOf('week').add(3, 'day');
+    expect(updateMock).toHaveBeenCalledWith(middleDate.format('MM'), middleDate.format('YYYY'));
   });
 
   // ref 테스트

--- a/index.d.ts
+++ b/index.d.ts
@@ -266,6 +266,8 @@ export interface CalendarStripProps {
   
   /**
    * Callback to update month/year in parent component
+   * @param month Two-digit month string ('MM')
+   * @param year Four-digit year string ('YYYY')
    */
   updateMonthYear?: (month: string, year: string) => void;
   

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -294,8 +294,13 @@ const CalendarStrip = ({
     }
     
     if (centerWeek && updateMonthYear) {
-      const middleDate = dayjs(centerWeek.startDate).add(Math.floor(numDaysInWeek / 2), 'day');
-      updateMonthYear(middleDate);
+      const middleDate = dayjs(centerWeek.startDate).add(
+        Math.floor(numDaysInWeek / 2),
+        'day'
+      );
+      const month = middleDate.format('MM');
+      const year = middleDate.format('YYYY');
+      updateMonthYear(month, year);
     }
   }, [weeks, onWeekChanged, updateMonthYear, numDaysInWeek, CENTER_INDEX]);
 


### PR DESCRIPTION
## Summary
- send month/year strings to `updateMonthYear`
- clarify callback API docs
- test `updateMonthYear` formatting

## Testing
- `npm test` *(fails: ESLint requires new config)*

------
https://chatgpt.com/codex/tasks/task_b_688646efd0c883228c72cdecd16a411c