### PR TITLE
Expose more calendar ref methods

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -300,36 +300,44 @@ const CalendarStrip = ({
   }, [weeks, onWeekChanged, updateMonthYear, numDaysInWeek, CENTER_INDEX]);
 
   // Imperative methods
-  React.useImperativeHandle(calendarRef, () => ({
-    scrollToDate: (date) => {
+  React.useImperativeHandle(calendarRef, () => {
+    const handleScrollToDate = (date) => {
       setActiveDate(date);
-      
+
       // Rebuild carousel around new date
       const newWeeks = initCarousel();
       setWeeks(newWeeks);
-      
+
       setTimeout(() => {
         if (flatListRef.current) {
           flatListRef.current.scrollToIndex({ index: CENTER_INDEX, animated: true });
         }
       }, 100);
-    },
-    getSelectedDate: () => activeDate,
-    goToNextWeek: () => {
-      const centerWeek = weeks[CENTER_INDEX];
-      if (centerWeek) {
-        const nextWeekStart = getWeekStart(centerWeek.startDate).add(numDaysInWeek, 'day');
-        setActiveDate(nextWeekStart.toDate());
-      }
-    },
-    goToPreviousWeek: () => {
-      const centerWeek = weeks[CENTER_INDEX];
-      if (centerWeek) {
-        const prevWeekStart = getWeekStart(centerWeek.startDate).subtract(numDaysInWeek, 'day');
-        setActiveDate(prevWeekStart.toDate());
-      }
-    }
-  }));
+    };
+
+    return {
+      jumpToDate: handleScrollToDate,
+      scrollToDate: handleScrollToDate,
+      getSelectedDate: () => activeDate,
+      goToNextWeek: () => {
+        const centerWeek = weeks[CENTER_INDEX];
+        if (centerWeek) {
+          const nextWeekStart = getWeekStart(centerWeek.startDate).add(numDaysInWeek, 'day');
+          setActiveDate(nextWeekStart.toDate());
+        }
+      },
+      goToPreviousWeek: () => {
+        const centerWeek = weeks[CENTER_INDEX];
+        if (centerWeek) {
+          const prevWeekStart = getWeekStart(centerWeek.startDate).subtract(numDaysInWeek, 'day');
+          setActiveDate(prevWeekStart.toDate());
+        }
+      },
+      getCurrentWeek: () => weeks[CENTER_INDEX] || null,
+      getWeeks: () => weeks,
+      getCurrentWeekIndex: () => CENTER_INDEX,
+    };
+  });
 
   // Date selection handler
   const handleDateSelection = useCallback(date => {


### PR DESCRIPTION
## Summary
- add jumpToDate alias and helpers in `useImperativeHandle`
- expose getters for current week and week list

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_688646f756a883229ed99838c06a87d2