### PR TITLE
Remove unused WeekSelector props

### DIFF
--- a/__tests__/WeekSelector.js
+++ b/__tests__/WeekSelector.js
@@ -12,12 +12,7 @@ const today = dayjs();
 describe("WeekSelector Component", () => {
   it("should render without issues", () => {
     const component = shallow(
-      <WeekSelector
-        controlDate={today}
-        weekStartDate={today}
-        weekEndDate={today.clone().add(1, "week")}
-        size={50}
-      />
+      <WeekSelector size={50} />
     );
 
     expect(component).toBeTruthy();

--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -13,9 +13,6 @@ WeekSelector.propTypes = {
   icon: PropTypes.any,
   size: PropTypes.number,
   children: PropTypes.node,
-  controlDate: PropTypes.any,
-  weekStartDate: PropTypes.any,
-  weekEndDate: PropTypes.any,
 };
 
 export default WeekSelector;


### PR DESCRIPTION
## Summary
- drop `controlDate`, `weekStartDate`, and `weekEndDate` from `WeekSelector` propTypes
- update WeekSelector test accordingly

## Testing
- `npm test` *(fails: ESLint 9 flat config error)*

------
https://chatgpt.com/codex/tasks/task_b_6886470dda388322a9e71e7152bdd55c