### PR TITLE
Remove unused is2WeekView option

### DIFF
--- a/__tests__/CalendarController.js
+++ b/__tests__/CalendarController.js
@@ -106,22 +106,6 @@ describe('CalendarController', () => {
       expect(week.days.length).toBe(5);
     });
     
-    it('should handle 2-week view with useIsoWeekday', () => {
-      const customController = new CalendarController({
-        useIsoWeekday: true,
-        is2WeekView: true
-      });
-      
-      // 임의의 날짜로 주 생성
-      const startDate = dayjs('2025-01-06'); 
-      const week = customController._generateWeek(startDate);
-      
-      // 결과가 유효한지 확인
-      expect(week).toBeDefined();
-      expect(week.days).toBeDefined();
-      expect(week.startDate).toBeDefined();
-      expect(week.endDate).toBeDefined();
-    });
   });
   
   describe('findWeekIndexByDate', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -395,7 +395,6 @@ export class CalendarController {
     numDaysInWeek?: number;
     minDate?: Date;
     maxDate?: Date;
-    is2WeekView?: boolean;
   });
   addListener(listener: Function): () => void;
   jumpToDate(date: Date): void;

--- a/src/controllers/CalendarController.js
+++ b/src/controllers/CalendarController.js
@@ -8,7 +8,6 @@ class CalendarController {
       numDaysInWeek: options.numDaysInWeek || 7,
       minDate: options.minDate ? dayjs(options.minDate) : undefined,
       maxDate: options.maxDate ? dayjs(options.maxDate) : undefined,
-      is2WeekView: options.is2WeekView || false,
     };
 
     this._listeners = new Set();


### PR DESCRIPTION
## Summary
- drop `is2WeekView` from CalendarController options
- update type definitions
- remove 2-week view test

## Testing
- `npm test` *(fails: ESLint 9 requires config)*

------
https://chatgpt.com/codex/tasks/task_b_6886471333808322b3fcd7f1bb93da22