### PR TITLE
Remove unused react-native-pager-view dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "dayjs": "^1.11.9",
     "node-git-hooks": "^1.0.1",
-    "prop-types": "^15.6.0",
-    "react-native-pager-view": "^6.8.1"
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
## Summary
- remove `react-native-pager-view` from dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68864a7c9b5883228289eea8ea9e6dc4