### PR TITLE
Shift weeks on scroll end

### DIFF
--- a/__tests__/CalendarStripShift.js
+++ b/__tests__/CalendarStripShift.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { FlatList } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import CalendarStrip from '../src/components/CalendarStrip';
+
+function getItemWidth(flatList) {
+  return flatList.props.getItemLayout([], 0).length;
+}
+
+describe('CalendarStrip week shifting', () => {
+  test('shifts right only once per swipe', () => {
+    const ref = React.createRef();
+    const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
+    const list = UNSAFE_getByType(FlatList);
+    const width = getItemWidth(list);
+    const before = ref.current.getCurrentWeek().startDate;
+
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width * 2 } } });
+    // second event from internal reset
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
+
+    const after = ref.current.getCurrentWeek().startDate;
+    expect(dayjs(after).diff(dayjs(before), 'day')).toBe(7);
+    expect(ref.current.getWeeks()).toHaveLength(3);
+  });
+
+  test('shifts left only once per swipe', () => {
+    const ref = React.createRef();
+    const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
+    const list = UNSAFE_getByType(FlatList);
+    const width = getItemWidth(list);
+    const before = ref.current.getCurrentWeek().startDate;
+
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: 0 } } });
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
+
+    const after = ref.current.getCurrentWeek().startDate;
+    expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
+    expect(ref.current.getWeeks()).toHaveLength(3);
+  });
+});

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -280,29 +280,23 @@ const CalendarStrip = ({
     return shifted;
   }, [generateWeek, getWeekStart, numDaysInWeek, maxDate, WINDOW_SIZE]);
 
-  const onScroll = useCallback((event) => {
-    const currentOffset = event.nativeEvent.contentOffset.x;
-    const itemWidth = contentWidth;
-    const threshold = itemWidth * 0.3; // 30% threshold for instant response
-    if (__DEV__) {
-      console.log('[CAROUSEL] Scroll offset:', currentOffset, 'Threshold:', threshold);
-    }
+  const onScrollEnd = useCallback(
+    (event) => {
+      const currentOffset = event.nativeEvent.contentOffset.x;
+      const itemWidth = contentWidth;
+      const page = Math.round(itemWidth ? currentOffset / itemWidth : 1);
+      if (__DEV__) {
+        console.log('[CAROUSEL] Scroll end page:', page, 'offset:', currentOffset);
+      }
 
-    // Left threshold: user scrolled 30% into previous week
-    if (currentOffset < threshold) {
-      if (__DEV__) {
-        console.log('[CAROUSEL] Left threshold reached - instant shift');
+      if (page === 0) {
+        shiftLeft();
+      } else if (page === 2) {
+        shiftRight();
       }
-      shiftLeft();
-    }
-    // Right threshold: user scrolled 30% into next week
-    else if (currentOffset > itemWidth * 2 - threshold) {
-      if (__DEV__) {
-        console.log('[CAROUSEL] Right threshold reached - instant shift');
-      }
-      shiftRight();
-    }
-  }, [contentWidth, shiftLeft, shiftRight]);
+    },
+    [contentWidth, shiftLeft, shiftRight]
+  );
 
   
   // Simplified viewable items handler - just for callbacks
@@ -500,7 +494,8 @@ const CalendarStrip = ({
             pagingEnabled={scrollerPaging}
             showsHorizontalScrollIndicator={false}
             getItemLayout={getItemLayout}
-            onScroll={onScroll}
+            onMomentumScrollEnd={onScrollEnd}
+            onScrollEndDrag={onScrollEnd}
             viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs.current}
             initialScrollIndex={CENTER_INDEX}
           />


### PR DESCRIPTION
## Summary
- shift weeks when swiping ends
- add regression tests to ensure single week shift per swipe

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68864a87135883229a8f20548938b3e7