### PR TITLE
Fix README scrollable default

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ AppRegistry.registerComponent('Example', () => Example);
 | Prop                 | Description                                                                                                                                                        | Type     | Default    |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------- |
 | **`numDaysInWeek`**  | Number of days shown in week. Applicable only when scrollable is false.                                                                                            | Number   | **`7`**    |
-| **`scrollable`**     | Dates are scrollable if true.                                                                                                                                      | Bool     | **`False`**|
-| **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true).                                                                        | Bool     | **`True`**|
+| **`scrollable`**     | Dates are scrollable if true. | Bool     | **`True`** |
+| **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true). | Bool     | **`True`** |
 | **`weekBuffer`**     | Number of weeks kept in memory when scrollable. The visible week plus this many weeks before and after will be rendered. Works with custom `numDaysInWeek`. | Number | **`3`** |
 | **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
 | **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |


### PR DESCRIPTION
## Summary
- clarify that `scrollable` defaults to `true` in the English props table

## Testing
- `npm test` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_688649399ae08322bb7b0d5d9096b03d