### PR TITLE
Improve shift logic and tests

### DIFF
--- a/__tests__/CalendarStripShift.js
+++ b/__tests__/CalendarStripShift.js
@@ -39,4 +39,37 @@ describe('CalendarStrip week shifting', () => {
     expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
     expect(ref.current.getWeeks()).toHaveLength(3);
   });
+
+  test('ignores additional right swipe while shifting', () => {
+    const ref = React.createRef();
+    const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
+    const list = UNSAFE_getByType(FlatList);
+    const width = getItemWidth(list);
+    const before = ref.current.getCurrentWeek().startDate;
+
+    // first swipe
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width * 2 } } });
+    // user quickly swipes again before internal reset
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width * 2 } } });
+    // internal event from first swipe
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
+
+    const after = ref.current.getCurrentWeek().startDate;
+    expect(dayjs(after).diff(dayjs(before), 'day')).toBe(7);
+  });
+
+  test('ignores additional left swipe while shifting', () => {
+    const ref = React.createRef();
+    const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
+    const list = UNSAFE_getByType(FlatList);
+    const width = getItemWidth(list);
+    const before = ref.current.getCurrentWeek().startDate;
+
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: 0 } } });
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: 0 } } });
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
+
+    const after = ref.current.getCurrentWeek().startDate;
+    expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
+  });
 });

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -246,10 +246,7 @@ const CalendarStrip = ({
       return [newWeek, ...currentWeeks.slice(0, WINDOW_SIZE - 1)];
     });
 
-    setTimeout(() => {
-      flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
-      isShiftingRef.current = false;
-    }, 0);
+    flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
 
     return shifted;
   }, [generateWeek, getWeekStart, numDaysInWeek, minDate, WINDOW_SIZE]);
@@ -272,10 +269,7 @@ const CalendarStrip = ({
       return [...currentWeeks.slice(1), newWeek];
     });
 
-    setTimeout(() => {
-      flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
-      isShiftingRef.current = false;
-    }, 0);
+    flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
 
     return shifted;
   }, [generateWeek, getWeekStart, numDaysInWeek, maxDate, WINDOW_SIZE]);
@@ -287,6 +281,13 @@ const CalendarStrip = ({
       const page = Math.round(itemWidth ? currentOffset / itemWidth : 1);
       if (__DEV__) {
         console.log('[CAROUSEL] Scroll end page:', page, 'offset:', currentOffset);
+      }
+
+      if (isShiftingRef.current) {
+        if (page === CENTER_INDEX) {
+          isShiftingRef.current = false;
+        }
+        return;
       }
 
       if (page === 0) {


### PR DESCRIPTION
## Summary
- avoid clearing `isShiftingRef` inside `shiftLeft`/`shiftRight`
- add guard in `onScrollEnd` so mid-shift events are ignored
- add tests for fast swipe sequences

## Testing
- `npm test` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6886525a6a3c83228ecfcb6538115a67