### PR TITLE
Queue swipe shifts

### DIFF
--- a/__tests__/CalendarStripShift.js
+++ b/__tests__/CalendarStripShift.js
@@ -40,25 +40,23 @@ describe('CalendarStrip week shifting', () => {
     expect(ref.current.getWeeks()).toHaveLength(3);
   });
 
-  test('ignores additional right swipe while shifting', () => {
+  test('queues additional right swipe while shifting', () => {
     const ref = React.createRef();
     const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
     const list = UNSAFE_getByType(FlatList);
     const width = getItemWidth(list);
     const before = ref.current.getCurrentWeek().startDate;
 
-    // first swipe
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width * 2 } } });
-    // user quickly swipes again before internal reset
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width * 2 } } });
-    // internal event from first swipe
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
 
     const after = ref.current.getCurrentWeek().startDate;
-    expect(dayjs(after).diff(dayjs(before), 'day')).toBe(7);
+    expect(dayjs(after).diff(dayjs(before), 'day')).toBe(14);
   });
 
-  test('ignores additional left swipe while shifting', () => {
+  test('queues additional left swipe while shifting', () => {
     const ref = React.createRef();
     const { UNSAFE_getByType } = render(<CalendarStrip ref={ref} showMonth={false} />);
     const list = UNSAFE_getByType(FlatList);
@@ -68,8 +66,9 @@ describe('CalendarStrip week shifting', () => {
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: 0 } } });
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: 0 } } });
     fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
+    fireEvent(list, 'momentumScrollEnd', { nativeEvent: { contentOffset: { x: width } } });
 
     const after = ref.current.getCurrentWeek().startDate;
-    expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
+    expect(dayjs(before).diff(dayjs(after), 'day')).toBe(14);
   });
 });

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -226,9 +226,13 @@ const CalendarStrip = ({
 
   // True Carousel: Real-time scroll threshold detection
   const isShiftingRef = useRef(false);
+  const pendingShiftRef = useRef([]);
   
   const shiftLeft = useCallback(() => {
-    if (isShiftingRef.current) return false;
+    if (isShiftingRef.current) {
+      pendingShiftRef.current.push('left');
+      return false;
+    }
     isShiftingRef.current = true;
 
     let shifted = false;
@@ -252,7 +256,10 @@ const CalendarStrip = ({
   }, [generateWeek, getWeekStart, numDaysInWeek, minDate, WINDOW_SIZE]);
 
   const shiftRight = useCallback(() => {
-    if (isShiftingRef.current) return false;
+    if (isShiftingRef.current) {
+      pendingShiftRef.current.push('right');
+      return false;
+    }
     isShiftingRef.current = true;
 
     let shifted = false;
@@ -286,6 +293,12 @@ const CalendarStrip = ({
       if (isShiftingRef.current) {
         if (page === CENTER_INDEX) {
           isShiftingRef.current = false;
+          const next = pendingShiftRef.current.shift();
+          if (next === 'left') {
+            shiftLeft();
+          } else if (next === 'right') {
+            shiftRight();
+          }
         }
         return;
       }


### PR DESCRIPTION
## Summary
- queue multiple swipe gestures with `pendingShiftRef`
- trigger additional shift on scroll end when queued
- update shift tests for queued swipes

## Testing
- `npm test` *(fails: ESLint couldn't run because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68865b332b448322878c5f21e42af325