### PR TITLE
Fix onWeekChanged dayjs usage

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -71,7 +71,7 @@ yarn add atflee_react-native-calendar-strip
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `onDateSelected` | `Function` | `undefined` | 날짜 선택 시 호출되는 콜백: `(date) => void` |
-| `onWeekChanged` | `Function` | `undefined` | 주 변경 시 호출되는 콜백: `(start, end) => void` |
+| `onWeekChanged` | `Function` | `undefined` | 주 변경 시 호출되는 콜백: `(start: Dayjs, end: Dayjs) => void` |
 | `onHeaderSelected` | `Function` | `undefined` | 헤더 선택 시 호출되는 콜백: `() => void` |
 | `updateMonthYear` | `Function` | `undefined` | 표시되는 월/연도 업데이트 시 호출되는 콜백: `(month, year) => void` (`month`: `MM`, `year`: `YYYY`) |
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
 | **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |
 | **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` dayjs date.                                                                      | Function |
-| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. Receives params `(start, end)` dayjs dates.                                                             | Function |
+| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. Receives params `(start, end)` as `dayjs.Dayjs` objects. | Function |
 | **`onWeekScrollStart`**| Function to be used as a callback in `scrollable` mode when dates page starts gliding. Receives params `(start, end)` dayjs dates.                              | Function |
 | **`onWeekScrollEnd`**| Function to be used as a callback in `scrollable` mode when dates page stops gliding. Receives params `(start, end)` dayjs dates.                                 | Function |
 | **`onHeaderSelected`**| Function to be used as a callback when the header is selected. Receives param object `{weekStartDate, weekEndDate}` dayjs dates.                                 | Function |

--- a/__tests__/CalendarStripShift.js
+++ b/__tests__/CalendarStripShift.js
@@ -72,4 +72,22 @@ describe('CalendarStrip week shifting', () => {
     const after = ref.current.getCurrentWeek().startDate;
     expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
   });
+
+  test('onWeekChanged receives dayjs objects during rapid updates', () => {
+    const onWeekChanged = jest.fn();
+    const { UNSAFE_getByType } = render(
+      <CalendarStrip showMonth={false} onWeekChanged={onWeekChanged} />
+    );
+    const list = UNSAFE_getByType(FlatList);
+    const callback = list.props.viewabilityConfigCallbackPairs[0].onViewableItemsChanged;
+
+    callback({ viewableItems: [{ index: 1 }] });
+    callback({ viewableItems: [{ index: 1 }] });
+
+    expect(onWeekChanged).toHaveBeenCalled();
+    onWeekChanged.mock.calls.forEach(args => {
+      expect(dayjs.isDayjs(args[0])).toBe(true);
+      expect(dayjs.isDayjs(args[1])).toBe(true);
+    });
+  });
 });

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -304,7 +304,7 @@ const CalendarStrip = ({
   const onViewableItemsChanged = useCallback(({ viewableItems }) => {
     const centerWeek = weeks[CENTER_INDEX];
     if (centerWeek && onWeekChanged) {
-      onWeekChanged(centerWeek.startDate, centerWeek.endDate);
+      onWeekChanged(dayjs(centerWeek.startDate), dayjs(centerWeek.endDate));
     }
     
     if (centerWeek && updateMonthYear) {
@@ -469,6 +469,12 @@ const CalendarStrip = ({
   const viewabilityConfigCallbackPairs = useRef([
     { viewabilityConfig, onViewableItemsChanged }
   ]);
+
+  useEffect(() => {
+    viewabilityConfigCallbackPairs.current = [
+      { viewabilityConfig, onViewableItemsChanged }
+    ];
+  }, [onViewableItemsChanged]);
 
   return (
     <View style={[styles.container, style]} onLayout={onLayout}>


### PR DESCRIPTION
## Summary
- convert `centerWeek` date args to `dayjs` before calling `onWeekChanged`
- refresh `viewabilityConfigCallbackPairs` when handler changes
- document the Dayjs callback types
- test that `onWeekChanged` receives Dayjs objects

## Testing
- `npm test --silent` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68865b31e3588322b55460061f0e3732