### PR TITLE
Improve initial centering logic

### DIFF
--- a/__tests__/CalendarStripCentering.js
+++ b/__tests__/CalendarStripCentering.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
+import CalendarStrip from '../src/components/CalendarStrip';
+
+describe('CalendarStrip initial centering', () => {
+  it('centers FlatList without delay when paging enabled', () => {
+    const spy = jest.spyOn(FlatList.prototype, 'scrollToIndex').mockImplementation(() => {});
+    render(<CalendarStrip showMonth={false} scrollerPaging />);
+    expect(spy).toHaveBeenCalledWith({ index: 1, animated: true });
+    spy.mockRestore();
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      parser: 'babel-eslint',
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+    settings: { react: { version: '16.13' } },
+    rules: {},
+  },
+];

--- a/index.d.ts
+++ b/index.d.ts
@@ -270,6 +270,12 @@ export interface CalendarStripProps {
    * @param year Four-digit year string ('YYYY')
    */
   updateMonthYear?: (month: string, year: string) => void;
+
+  /**
+   * Callback invoked after initial render is complete
+   * and the list has been centered. Receives the render time in ms.
+   */
+  onRenderComplete?: (renderTimeMs: number) => void;
   
   // Custom components
   /**


### PR DESCRIPTION
## Summary
- center list with `useLayoutEffect`
- expose `onRenderComplete` callback
- add test for immediate centering
- provide minimal ESLint config for tests

## Testing
- `npm test` *(fails: ESLint config/parsing issues)*


------
https://chatgpt.com/codex/tasks/task_b_68865b32455083229e90b40c5a2a3215