### PR TITLE
Fix viewabilityConfigCallbackPairs reference

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -534,7 +534,7 @@ const CalendarStrip = ({
             getItemLayout={getItemLayout}
             onMomentumScrollEnd={onScrollEnd}
             onScrollEndDrag={onScrollEnd}
-            viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs}
+            viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs.current}
             initialScrollIndex={CENTER_INDEX}
           />
         ) : (


### PR DESCRIPTION
## Summary
- use `viewabilityConfigCallbackPairs.current` when passing to `FlatList`

## Testing
- `npm test` *(fails: ESLint requires parser)*

------
https://chatgpt.com/codex/tasks/task_b_68866180a6d8832286119b03966d9f1c