### PR TITLE
Add viewability config array stability test

### DIFF
--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -75,4 +75,25 @@ describe('CalendarStrip functional API', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  test('reuses viewabilityConfigCallbackPairs array across renders', () => {
+    const firstCb = jest.fn();
+    const { UNSAFE_getByType, rerender } = render(
+      <CalendarStrip showMonth={false} onViewableItemsChanged={firstCb} />
+    );
+
+    const flatList1 = UNSAFE_getByType(FlatList);
+    const pairs1 = flatList1.props.viewabilityConfigCallbackPairs;
+
+    const secondCb = jest.fn();
+    rerender(
+      <CalendarStrip showMonth={false} onViewableItemsChanged={secondCb} />
+    );
+
+    const flatList2 = UNSAFE_getByType(FlatList);
+    const pairs2 = flatList2.props.viewabilityConfigCallbackPairs;
+
+    expect(pairs2).toBe(pairs1);
+    expect(pairs2[0].onViewableItemsChanged).toBe(secondCb);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `viewabilityConfigCallbackPairs` array reference is stable across rerenders

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68866eef4e008322a3c13581281b71d7