### PR TITLE
Switch to @babel/eslint-parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "env": {
         "es6": true,
         "browser": true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,10 @@
+import babelParser from '@babel/eslint-parser';
+
 export default [
   {
     files: ['**/*.js'],
     languageOptions: {
-      parser: 'babel-eslint',
+      parser: babelParser,
       ecmaVersion: 2020,
       sourceType: 'module',
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react": "^17.0.0",
     "@types/react-native": "^0.63.37",
     "all-contributors-cli": "^4.10.1",
-    "babel-eslint": "^8.0.3",
+    "@babel/eslint-parser": "^7.21.5",
     "babel-jest": "^26.6.3",
     "babel-preset-react-native": "^4.0.0",
     "enzyme": "^3.2.0",


### PR DESCRIPTION
## Summary
- update ESLint parser package
- update flat config to import the new parser
- adjust `.eslintrc` for the same parser

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68866eed206c8322843d9fc850c814df