### PR TITLE
Add effect to sync week callbacks on shift

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -158,6 +158,24 @@ const CalendarStrip = ({
     logger.debug('[STATE] Initializing weeks state');
     return initCarousel();
   });
+
+  useEffect(() => {
+    const centerWeek = weeks[CENTER_INDEX];
+
+    if (centerWeek && onWeekChanged) {
+      onWeekChanged(dayjs(centerWeek.startDate), dayjs(centerWeek.endDate));
+    }
+
+    if (centerWeek && updateMonthYear) {
+      const middleDate = dayjs(centerWeek.startDate).add(
+        Math.floor(numDaysInWeek / 2),
+        'day'
+      );
+      const month = middleDate.format('MM');
+      const year = middleDate.format('YYYY');
+      updateMonthYear(month, year);
+    }
+  }, [weeks, onWeekChanged, updateMonthYear, numDaysInWeek]);
   const [activeDate, setActiveDate] = useState(() => {
     const date = selectedDate || startingDate || new Date();
     logger.debug('[STATE] Initial active date:', dayjs(date).format('YYYY-MM-DD'));


### PR DESCRIPTION
## Summary
- call `onWeekChanged` and `updateMonthYear` whenever weeks state changes

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68867513090c8322b556623184085b45