### PR TITLE
Implement weekBuffer prop for larger scroll window

### DIFF
--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -4,9 +4,9 @@ import { FlatList } from 'react-native';
 import CalendarStrip from '../src/components/CalendarStrip';
 
 describe('CalendarStrip functional API', () => {
-  test('renders three weeks of seven days by default', () => {
+  test('renders buffered weeks of seven days by default', () => {
     const { getAllByA11yRole } = render(<CalendarStrip showMonth={false} />);
-    expect(getAllByA11yRole('button')).toHaveLength(21);
+    expect(getAllByA11yRole('button')).toHaveLength(49);
   });
 
   test('respects numDaysInWeek prop', () => {

--- a/__tests__/CalendarStripCentering.js
+++ b/__tests__/CalendarStripCentering.js
@@ -7,7 +7,7 @@ describe('CalendarStrip initial centering', () => {
   it('centers FlatList without delay when paging enabled', () => {
     const spy = jest.spyOn(FlatList.prototype, 'scrollToIndex').mockImplementation(() => {});
     render(<CalendarStrip showMonth={false} scrollerPaging />);
-    expect(spy).toHaveBeenCalledWith({ index: 1, animated: true });
+    expect(spy).toHaveBeenCalledWith({ index: 3, animated: true });
     spy.mockRestore();
   });
 });

--- a/__tests__/CalendarStripShift.js
+++ b/__tests__/CalendarStripShift.js
@@ -22,7 +22,7 @@ describe('CalendarStrip week shifting', () => {
 
     const after = ref.current.getCurrentWeek().startDate;
     expect(dayjs(after).diff(dayjs(before), 'day')).toBe(7);
-    expect(ref.current.getWeeks()).toHaveLength(3);
+    expect(ref.current.getWeeks()).toHaveLength(7);
   });
 
   test('shifts left only once per swipe', () => {
@@ -37,7 +37,7 @@ describe('CalendarStrip week shifting', () => {
 
     const after = ref.current.getCurrentWeek().startDate;
     expect(dayjs(before).diff(dayjs(after), 'day')).toBe(7);
-    expect(ref.current.getWeeks()).toHaveLength(3);
+    expect(ref.current.getWeeks()).toHaveLength(7);
   });
 
   test('queues additional right swipe while shifting', () => {
@@ -80,8 +80,8 @@ describe('CalendarStrip week shifting', () => {
     const list = UNSAFE_getByType(FlatList);
     const callback = list.props.viewabilityConfigCallbackPairs[0].onViewableItemsChanged;
 
-    callback({ viewableItems: [{ index: 1 }] });
-    callback({ viewableItems: [{ index: 1 }] });
+    callback({ viewableItems: [{ index: 3 }] });
+    callback({ viewableItems: [{ index: 3 }] });
 
     expect(onWeekChanged).toHaveBeenCalled();
     onWeekChanged.mock.calls.forEach(args => {

--- a/__tests__/CalendarStripV2.js
+++ b/__tests__/CalendarStripV2.js
@@ -124,7 +124,7 @@ describe('CalendarStrip Component', () => {
 
     const flatList = UNSAFE_getByType(FlatList);
     const cb = flatList.props.viewabilityConfigCallbackPairs[0].onViewableItemsChanged;
-    cb({ viewableItems: [{ index: 1 }] });
+    cb({ viewableItems: [{ index: 3 }] });
 
     const middleDate = dayjs(startDate).startOf('week').add(3, 'day');
     expect(updateMock).toHaveBeenCalledWith(middleDate.format('MM'), middleDate.format('YYYY'));

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,6 +148,13 @@ export interface CalendarStripProps {
    * Whether to use paged scrolling
    */
   scrollerPaging?: boolean;
+
+  /**
+   * Number of weeks kept in memory when scrollable.
+   * Visible week plus this many weeks before and after will be rendered.
+   * @default 3
+   */
+  weekBuffer?: number;
   
   // Header configuration
   /**
@@ -401,6 +408,7 @@ export class CalendarController {
     initialDate?: Date;
     useIsoWeekday?: boolean;
     numDaysInWeek?: number;
+    weekBuffer?: number;
     minDate?: Date;
     maxDate?: Date;
   });

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -46,6 +46,7 @@ const CalendarStrip = ({
   numDaysInWeek = 7,
   scrollable,
   scrollerPaging,
+  weekBuffer = 3,
   
   // Header configuration
   showMonth,
@@ -91,9 +92,9 @@ const CalendarStrip = ({
   // Reference
   calendarRef
 }) => {
-  // Carousel constants - 3 items: [prev, current, next]
-  const WINDOW_SIZE = 3;
-  const CENTER_INDEX = 1;
+  // Carousel constants - dynamic window based on weekBuffer
+  const WINDOW_SIZE = weekBuffer * 2 + 1;
+  const CENTER_INDEX = weekBuffer;
 
   // FlatList reference
   const flatListRef = useRef(null);
@@ -141,8 +142,8 @@ const CalendarStrip = ({
     
     const weeks = [];
     
-    // Generate 3 weeks: 1 before, current, 1 after
-    for (let i = -1; i <= 1; i++) {
+    // Generate window of weeks around the active date
+    for (let i = -weekBuffer; i <= weekBuffer; i++) {
       const start = weekStart.add(i * numDaysInWeek, 'day');
       const week = generateWeek(start);
       logger.debug(`[INIT] Week ${i + 1}:`, dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
@@ -319,7 +320,7 @@ const CalendarStrip = ({
 
       if (page === 0) {
         shiftLeft();
-      } else if (page === 2) {
+      } else if (page === WINDOW_SIZE - 1) {
         shiftRight();
       }
     },
@@ -596,6 +597,7 @@ CalendarStrip.propTypes = {
   numDaysInWeek: PropTypes.number,
   scrollable: PropTypes.bool,
   scrollerPaging: PropTypes.bool,
+  weekBuffer: PropTypes.number,
 
   // Header configuration
   showMonth: PropTypes.bool,
@@ -666,6 +668,7 @@ CalendarStrip.defaultProps = {
   numDaysInWeek: 7,
   scrollable: true,
   scrollerPaging: true,
+  weekBuffer: 3,
 
   // Header configuration defaults
   showMonth: true,


### PR DESCRIPTION
## Summary
- add `weekBuffer` prop to CalendarStrip for preloading extra weeks
- update carousel logic to use dynamic window size
- document new prop in type definitions
- adjust unit tests for new defaults

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_688678775a7c8322b8f72f8062203c11