### PR TITLE
Fix non-scrollable initCarousel behavior

### DIFF
--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -5,8 +5,12 @@ import CalendarStrip from '../src/components/CalendarStrip';
 
 describe('CalendarStrip functional API', () => {
   test('renders buffered weeks of seven days by default', () => {
-    const { getAllByA11yRole } = render(<CalendarStrip showMonth={false} />);
+    const ref = React.createRef();
+    const { getAllByA11yRole } = render(
+      <CalendarStrip showMonth={false} ref={ref} />
+    );
     expect(getAllByA11yRole('button')).toHaveLength(49);
+    expect(ref.current.getWeeks()).toHaveLength(7);
   });
 
   test('respects numDaysInWeek prop', () => {
@@ -17,10 +21,12 @@ describe('CalendarStrip functional API', () => {
   });
 
   test('renders a single week when not scrollable', () => {
+    const ref = React.createRef();
     const { getAllByA11yRole } = render(
-      <CalendarStrip showMonth={false} scrollable={false} />
+      <CalendarStrip showMonth={false} scrollable={false} ref={ref} />
     );
     expect(getAllByA11yRole('button')).toHaveLength(7);
+    expect(ref.current.getWeeks()).toHaveLength(1);
   });
 
   test('exposes imperative methods via ref', () => {

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -139,20 +139,27 @@ const CalendarStrip = ({
 
     const weekStart = getWeekStart(currentDate);
     logger.debug('[INIT] Week start:', weekStart.format('YYYY-MM-DD'));
-    
+
     const weeks = [];
-    
-    // Generate window of weeks around the active date
-    for (let i = -weekBuffer; i <= weekBuffer; i++) {
-      const start = weekStart.add(i * numDaysInWeek, 'day');
-      const week = generateWeek(start);
-      logger.debug(`[INIT] Week ${i + 1}:`, dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
+
+    if (!scrollable) {
+      // Only generate the current week when not scrollable
+      const week = generateWeek(weekStart);
+      logger.debug('[INIT] Week 1:', dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
       weeks.push(week);
+    } else {
+      // Generate window of weeks around the active date
+      for (let i = -weekBuffer; i <= weekBuffer; i++) {
+        const start = weekStart.add(i * numDaysInWeek, 'day');
+        const week = generateWeek(start);
+        logger.debug(`[INIT] Week ${i + 1}:`, dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
+        weeks.push(week);
+      }
     }
 
     logger.debug('[INIT] Created', weeks.length, 'weeks');
     return weeks;
-  }, [selectedDate, startingDate, getWeekStart, generateWeek, numDaysInWeek]);
+  }, [selectedDate, startingDate, getWeekStart, generateWeek, numDaysInWeek, scrollable, weekBuffer]);
 
   // State - Fixed carousel window
   const [weeks, setWeeks] = useState(() => {


### PR DESCRIPTION
## Summary
- create just one week in `initCarousel` when `scrollable` is false
- check week count via ref in CalendarStrip tests

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68867b7cd96883229b4c5cf56589b39e