### PR TITLE
Fix weekBuffer dependency handling

### DIFF
--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -96,4 +96,20 @@ describe('CalendarStrip functional API', () => {
     expect(pairs2).toBe(pairs1);
     expect(pairs2[0].onViewableItemsChanged).toBe(secondCb);
   });
+
+  test('updating weekBuffer re-creates weeks array', () => {
+    const ref = React.createRef();
+    const { rerender } = render(
+      <CalendarStrip showMonth={false} weekBuffer={1} ref={ref} />
+    );
+
+    const weeksBefore = ref.current.getWeeks();
+    expect(weeksBefore).toHaveLength(3);
+
+    rerender(<CalendarStrip showMonth={false} weekBuffer={2} ref={ref} />);
+
+    const weeksAfter = ref.current.getWeeks();
+    expect(weeksAfter).toHaveLength(5);
+    expect(weeksAfter).not.toBe(weeksBefore);
+  });
 });

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -152,7 +152,14 @@ const CalendarStrip = ({
 
     logger.debug('[INIT] Created', weeks.length, 'weeks');
     return weeks;
-  }, [selectedDate, startingDate, getWeekStart, generateWeek, numDaysInWeek]);
+  }, [
+    selectedDate,
+    startingDate,
+    getWeekStart,
+    generateWeek,
+    numDaysInWeek,
+    weekBuffer,
+  ]);
 
   // State - Fixed carousel window
   const [weeks, setWeeks] = useState(() => {
@@ -270,7 +277,14 @@ const CalendarStrip = ({
     flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
 
     return shifted;
-  }, [generateWeek, getWeekStart, numDaysInWeek, minDate, WINDOW_SIZE]);
+  }, [
+    generateWeek,
+    getWeekStart,
+    numDaysInWeek,
+    minDate,
+    WINDOW_SIZE,
+    weekBuffer,
+  ]);
 
   const shiftRight = useCallback(() => {
     if (isShiftingRef.current) {
@@ -296,7 +310,14 @@ const CalendarStrip = ({
     flatListRef.current?.scrollToIndex({ index: CENTER_INDEX, animated: false });
 
     return shifted;
-  }, [generateWeek, getWeekStart, numDaysInWeek, maxDate, WINDOW_SIZE]);
+  }, [
+    generateWeek,
+    getWeekStart,
+    numDaysInWeek,
+    maxDate,
+    WINDOW_SIZE,
+    weekBuffer,
+  ]);
 
   const onScrollEnd = useCallback(
     (event) => {
@@ -344,7 +365,14 @@ const CalendarStrip = ({
       const year = middleDate.format('YYYY');
       updateMonthYear(month, year);
     }
-  }, [weeks, onWeekChanged, updateMonthYear, numDaysInWeek, CENTER_INDEX]);
+  }, [
+    weeks,
+    onWeekChanged,
+    updateMonthYear,
+    numDaysInWeek,
+    CENTER_INDEX,
+    weekBuffer,
+  ]);
 
   // Imperative methods
   React.useImperativeHandle(calendarRef, () => {


### PR DESCRIPTION
## Summary
- include `weekBuffer` in carousel initialization and callbacks
- add test verifying week data updates when `weekBuffer` changes

## Testing
- `npm run eslint` *(fails: Cannot find package '@babel/eslint-parser')*
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68867b7cd2ec8322bdeb88c6d7bfab6a