### PR TITLE
Support weekBuffer in CalendarController

### DIFF
--- a/__tests__/CalendarController.js
+++ b/__tests__/CalendarController.js
@@ -35,10 +35,14 @@ describe('CalendarController', () => {
     
     it('should initialize _weeks as an array', () => {
       // CalendarController는 생성자에서 _initialize()를 호출하여 미리 주변 주를 준비함
-      // 따라서 _weeks는 비어있지 않고 초기 주들이 들어있음
+      // 기본 weekBuffer 값은 3으로, 총 3주가 준비되어야 함
       expect(Array.isArray(controller._weeks)).toBe(true);
-      // 일반적으로 3주(이전, 현재, 다음) 정도가 미리 준비됨
-      expect(controller._weeks.length).toBeGreaterThan(0);
+      expect(controller._weeks.length).toBe(3);
+    });
+
+    it('should respect custom weekBuffer size', () => {
+      const customController = new CalendarController({ weekBuffer: 5 });
+      expect(customController.getWeeks().length).toBe(5);
     });
   });
   
@@ -134,6 +138,16 @@ describe('CalendarController', () => {
       
       const selectedDate = controller.getSelectedDate();
       expect(dayjs(selectedDate).format('YYYY-MM-DD')).toBe('2025-01-01');
+    });
+  });
+
+  describe('jumpToDate', () => {
+    it('should prepare weeks using weekBuffer', () => {
+      const custom = new CalendarController({ weekBuffer: 5 });
+      const target = dayjs().add(2, 'month').toDate();
+      custom.jumpToDate(target);
+      expect(custom.getWeeks().length).toBe(5);
+      expect(custom.getSelectedDate().isSame(dayjs(target), 'day')).toBe(true);
     });
   });
   

--- a/index.d.ts
+++ b/index.d.ts
@@ -408,6 +408,10 @@ export class CalendarController {
     initialDate?: Date;
     useIsoWeekday?: boolean;
     numDaysInWeek?: number;
+    /**
+     * Number of weeks prepared around the selected date.
+     * @default 3
+     */
     weekBuffer?: number;
     minDate?: Date;
     maxDate?: Date;

--- a/src/controllers/CalendarController.js
+++ b/src/controllers/CalendarController.js
@@ -6,6 +6,7 @@ class CalendarController {
       initialDate: options.initialDate || new Date(),
       useIsoWeekday: options.useIsoWeekday || false,
       numDaysInWeek: options.numDaysInWeek || 7,
+      weekBuffer: options.weekBuffer || 3,
       minDate: options.minDate ? dayjs(options.minDate) : undefined,
       maxDate: options.maxDate ? dayjs(options.maxDate) : undefined,
     };
@@ -19,7 +20,7 @@ class CalendarController {
   }
 
   _initialize() {
-    this._prepareWeeks(this._selectedDate, 3);
+    this._prepareWeeks(this._selectedDate, this._options.weekBuffer);
   }
 
   _getWeekStart(date) {
@@ -88,7 +89,7 @@ class CalendarController {
 
   jumpToDate(date) {
     this.selectDate(date);
-    this._prepareWeeks(dayjs(date), this._weeks.length || 3);
+    this._prepareWeeks(dayjs(date), this._options.weekBuffer);
   }
 
   goToNextWeek() {


### PR DESCRIPTION
## Summary
- allow CalendarController to accept `weekBuffer` option
- use `weekBuffer` when preparing weeks and jumping to dates
- document constructor option in types
- test custom week buffer behaviour

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68867b7d2c6c8322892dc45934b9edba