### PR TITLE
Fix missing current week refs

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -98,6 +98,10 @@ const CalendarStrip = ({
 
   // FlatList reference
   const flatListRef = useRef(null);
+  // Track the currently visible week to avoid redundant callbacks
+  const currentWeekRef = useRef(null);
+  // Skip onWeekChanged on initial render
+  const skipInitialRef = useRef(true);
 
   // Week generation utility
   const generateWeek = useCallback((startDate) => {


### PR DESCRIPTION
## Summary
- add `currentWeekRef` and `skipInitialRef` to track visible week
- document new refs

## Testing
- `npm test` *(fails: cannot find `@babel/eslint-parser`)*

------
https://chatgpt.com/codex/tasks/task_b_68867d94219c8322b663032cb841f6cb