### PR TITLE
Fix current month check

### DIFF
--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -115,7 +115,8 @@ const CalendarStrip = ({
         month: date.month(),
         year: date.year(),
         isToday: date.isSame(today, 'day'),
-        isCurrentMonth: date.month() === today.month()
+        isCurrentMonth:
+          date.month() === today.month() && date.year() === today.year()
       });
     }
     


### PR DESCRIPTION
## Summary
- fix the `isCurrentMonth` logic in `generateWeek`

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_6886802c42448322aa6dd20484668c2b