### PR TITLE
Fix week sync refs and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $ yarn add react-native-calendar-strip
 
 ### Scrollable CalendarStrip — New in 2.x
 
-The `scrollable` prop was introduced in 2.0.0 and features a bi-directional infinite scroller.  It uses React Native's [FlatList](https://reactnative.dev/docs/flatlist) to recycle days, shifting the dates as the ends are reached.  The Chrome debugger can cause issues with this updating due to a [RN setTimeout bug](https://github.com/facebook/react-native/issues/4470). To prevent date shifts at the ends of the scroller, set the `minDate` and `maxDate` range to a year or less.
+The `scrollable` prop was introduced in 2.0.0 and features a bi-directional infinite scroller.  By default it uses React Native's [FlatList](https://reactnative.dev/docs/flatlist) to recycle days.  For long ranges you can enable [`useFlashList`](#props) to use [FlashList](https://github.com/Shopify/flash-list) instead.  The Chrome debugger can cause issues with this updating due to a [RN setTimeout bug](https://github.com/facebook/react-native/issues/4470). To prevent date shifts at the ends of the scroller, set the `minDate` and `maxDate` range to a year or less.
 
 The refactor to support `scrollable` introduced internal changes to the `CalendarDay` component.  Users of the `dayComponent` prop may need to adjust their custom day component to accommodate the props passed to it.
 
@@ -331,7 +331,8 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`numDaysInWeek`**  | Number of days shown in week. Applicable only when scrollable is false.                                                                                            | Number   | **`7`**    |
 | **`scrollable`**     | Dates are scrollable if true. | Bool     | **`True`** |
 | **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true). | Bool     | **`True`** |
-| **`weekBuffer`**     | Number of weeks kept in memory when scrollable. The visible week plus this many weeks before and after will be rendered. Works with custom `numDaysInWeek`. | Number | **`3`** |
+| **`weekBuffer`**     | Number of weeks kept in memory when scrollable. The visible week plus this many weeks before and after will be rendered. Works with custom `numDaysInWeek`. Weeks are cached internally so raising this value has minimal performance impact. | Number | **`3`** |
+| **`useFlashList`**   | Use FlashList instead of FlatList for large buffers. Requires `@shopify/flash-list` dependency. | Bool | **`False`** |
 | **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
 | **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |
 | **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` dayjs date.                                                                      | Function |

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,6 +155,13 @@ export interface CalendarStripProps {
    * @default 3
    */
   weekBuffer?: number;
+
+  /**
+   * Use FlashList instead of FlatList for large buffers.
+   * Requires '@shopify/flash-list' dependency.
+   * @default false
+   */
+  useFlashList?: boolean;
   
   // Header configuration
   /**

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -47,6 +47,7 @@ const CalendarStrip = ({
   scrollable,
   scrollerPaging,
   weekBuffer = 3,
+  useFlashList = false,
   
   // Header configuration
   showMonth,
@@ -96,15 +97,27 @@ const CalendarStrip = ({
   const WINDOW_SIZE = weekBuffer * 2 + 1;
   const CENTER_INDEX = weekBuffer;
 
+  const ListComponent = useMemo(() => {
+    if (useFlashList) {
+      try {
+        // eslint-disable-next-line global-require
+        return require('@shopify/flash-list').FlashList;
+      } catch (err) {
+        logger.debug('[WARN] FlashList not installed, falling back to FlatList');
+      }
+    }
+    return FlatList;
+  }, [useFlashList]);
+
   // FlatList reference
   const flatListRef = useRef(null);
   // Track the currently visible week to avoid redundant callbacks
-  const currentWeekRef = useRef(null);
+  const currentWeekRef = useRef('');
   // Skip onWeekChanged on initial render
   const skipInitialRef = useRef(true);
 
-  const currentWeekRef = useRef('');
-  const skipInitialRef = useRef(true);
+  // Cache previously generated weeks to avoid regeneration when buffer is large
+  const weekCacheRef = useRef(new Map());
 
   // Week generation utility
   const generateWeek = useCallback((startDate) => {
@@ -139,11 +152,29 @@ const CalendarStrip = ({
     return useIsoWeekday ? d.startOf('isoWeek') : d.startOf('week');
   }, [useIsoWeekday]);
 
+  // Retrieve a week from cache or generate and store it
+  const getCachedWeek = useCallback(
+    (startDate) => {
+      const key = dayjs(startDate).startOf('day').format('YYYY-MM-DD');
+      const cached = weekCacheRef.current.get(key);
+      if (cached) {
+        return cached;
+      }
+      const week = generateWeek(startDate);
+      weekCacheRef.current.set(key, week);
+      return week;
+    },
+    [generateWeek]
+  );
+
   // Initialize carousel window
   const initCarousel = useCallback(() => {
     logger.debug('[INIT] Creating carousel window');
     const currentDate = selectedDate || startingDate || new Date();
     logger.debug('[INIT] Current date:', dayjs(currentDate).format('YYYY-MM-DD'));
+
+    // Clear cache when rebuilding the carousel to avoid stale weeks
+    weekCacheRef.current.clear();
 
     const weekStart = getWeekStart(currentDate);
     logger.debug('[INIT] Week start:', weekStart.format('YYYY-MM-DD'));
@@ -152,14 +183,14 @@ const CalendarStrip = ({
 
     if (!scrollable) {
       // Only generate the current week when not scrollable
-      const week = generateWeek(weekStart);
+      const week = getCachedWeek(weekStart);
       logger.debug('[INIT] Week 1:', dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
       weeks.push(week);
     } else {
       // Generate window of weeks around the active date
       for (let i = -weekBuffer; i <= weekBuffer; i++) {
         const start = weekStart.add(i * numDaysInWeek, 'day');
-        const week = generateWeek(start);
+        const week = getCachedWeek(start);
         logger.debug(`[INIT] Week ${i + 1}:`, dayjs(week.startDate).format('YYYY-MM-DD'), 'to', dayjs(week.endDate).format('YYYY-MM-DD'));
         weeks.push(week);
       }
@@ -171,7 +202,7 @@ const CalendarStrip = ({
     selectedDate,
     startingDate,
     getWeekStart,
-    generateWeek,
+    getCachedWeek,
     numDaysInWeek,
     weekBuffer,
   ]);
@@ -295,7 +326,7 @@ const CalendarStrip = ({
       }
 
       shifted = true;
-      const newWeek = generateWeek(prevWeekStart);
+      const newWeek = getCachedWeek(prevWeekStart);
       return [newWeek, ...currentWeeks.slice(0, WINDOW_SIZE - 1)];
     });
 
@@ -303,7 +334,7 @@ const CalendarStrip = ({
 
     return shifted;
   }, [
-    generateWeek,
+    getCachedWeek,
     getWeekStart,
     numDaysInWeek,
     minDate,
@@ -328,7 +359,7 @@ const CalendarStrip = ({
       }
 
       shifted = true;
-      const newWeek = generateWeek(nextWeekStart);
+      const newWeek = getCachedWeek(nextWeekStart);
       return [...currentWeeks.slice(1), newWeek];
     });
 
@@ -336,7 +367,7 @@ const CalendarStrip = ({
 
     return shifted;
   }, [
-    generateWeek,
+    getCachedWeek,
     getWeekStart,
     numDaysInWeek,
     maxDate,
@@ -556,7 +587,7 @@ const CalendarStrip = ({
         <View onLayout={onLeftLayout}>{leftSelector}</View>
         
         {scrollable ? (
-          <FlatList
+          <ListComponent
             ref={flatListRef}
             data={weeks}
             renderItem={renderWeek}
@@ -651,6 +682,7 @@ CalendarStrip.propTypes = {
   scrollable: PropTypes.bool,
   scrollerPaging: PropTypes.bool,
   weekBuffer: PropTypes.number,
+  useFlashList: PropTypes.bool,
 
   // Header configuration
   showMonth: PropTypes.bool,
@@ -722,6 +754,7 @@ CalendarStrip.defaultProps = {
   scrollable: true,
   scrollerPaging: true,
   weekBuffer: 3,
+  useFlashList: false,
 
   // Header configuration defaults
   showMonth: true,


### PR DESCRIPTION
## Summary
- remove duplicate refs
- cache generated weeks to reduce load when `weekBuffer` is large
- document internal week caching for higher `weekBuffer` values
- add optional FlashList support for large scroll ranges

## Testing
- `npm test --silent` *(fails: Cannot find package '@babel/eslint-parser')*


------
https://chatgpt.com/codex/tasks/task_b_68867eb067648322a6690c4a21394a8c