### PR TITLE
Implement innerStyle prop

### DIFF
--- a/__tests__/CalendarStrip.js
+++ b/__tests__/CalendarStrip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
+import { FlatList, View } from 'react-native';
 import CalendarStrip from '../src/components/CalendarStrip';
 
 describe('CalendarStrip functional API', () => {
@@ -117,5 +117,15 @@ describe('CalendarStrip functional API', () => {
     const weeksAfter = ref.current.getWeeks();
     expect(weeksAfter).toHaveLength(5);
     expect(weeksAfter).not.toBe(weeksBefore);
+  });
+
+  test('applies innerStyle to inner container', () => {
+    const { UNSAFE_getAllByType } = render(
+      <CalendarStrip showMonth={false} innerStyle={{ backgroundColor: 'red' }} />
+    );
+    const views = UNSAFE_getAllByType(View);
+    expect(views[1].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: 'red' })])
+    );
   });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,6 +190,11 @@ export interface CalendarStripProps {
    * Container style for the calendar
    */
   style?: StyleProp<ViewStyle>;
+
+  /**
+   * Style for the inner container view
+   */
+  innerStyle?: StyleProp<ViewStyle>;
   
   /**
    * Background color of the calendar

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -57,6 +57,7 @@ const CalendarStrip = ({
   
   // Styling
   style,
+  innerStyle,
   calendarColor,
   highlightColor,
   dateNameStyle,
@@ -573,18 +574,19 @@ const CalendarStrip = ({
 
   return (
     <View style={[styles.container, style]} onLayout={onLayout}>
-      {showMonth && (
-        <CalendarHeader
-          calendarHeaderFormat={calendarHeaderFormat}
-          calendarHeaderStyle={calendarHeaderStyle}
-          testID="calendar_header"
-          activeDate={activeDate}
-          onHeaderSelected={onHeaderSelected}
-        />
-      )}
-      
-      <View style={styles.calendarContainer}>
-        <View onLayout={onLeftLayout}>{leftSelector}</View>
+      <View style={[styles.inner, innerStyle]}>
+        {showMonth && (
+          <CalendarHeader
+            calendarHeaderFormat={calendarHeaderFormat}
+            calendarHeaderStyle={calendarHeaderStyle}
+            testID="calendar_header"
+            activeDate={activeDate}
+            onHeaderSelected={onHeaderSelected}
+          />
+        )}
+
+        <View style={styles.calendarContainer}>
+          <View onLayout={onLeftLayout}>{leftSelector}</View>
         
         {scrollable ? (
           <ListComponent
@@ -641,12 +643,16 @@ const CalendarStrip = ({
         <View onLayout={onRightLayout}>{rightSelector}</View>
       </View>
     </View>
+  </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     width: '100%',
+  },
+  inner: {
+    flex: 1,
   },
   calendarContainer: {
     flexDirection: 'row',
@@ -695,6 +701,7 @@ CalendarStrip.propTypes = {
 
   // Styling
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  innerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   calendarColor: PropTypes.string,
   highlightColor: PropTypes.string,
   dateNameStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
@@ -764,6 +771,7 @@ CalendarStrip.defaultProps = {
 
   // Styling defaults
   style: {},
+  innerStyle: {},
   calendarColor: '#fff',
   highlightColor: '#000',
   dateNameStyle: {},


### PR DESCRIPTION
## Summary
- add `innerStyle` prop to CalendarStrip component
- expose `innerStyle` in TypeScript types
- test rendering with the new prop

## Testing
- `npm test` *(fails: cannot find `@babel/eslint-parser`)*

------
https://chatgpt.com/codex/tasks/task_b_6886e504176c8322bbfd35aeb16e1347