### PR TITLE
Fix header position docs

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -39,7 +39,7 @@ yarn add atflee_react-native-calendar-strip
 | --- | --- | --- | --- |
 | `showMonth` | `boolean` | `true` | 월 헤더 표시 여부 |
 | `calendarHeaderFormat` | `string` | `'MMMM YYYY'` | 헤더 날짜 포맷(dayjs 형식) |
-| `calendarHeaderPosition` | `string` | `'top'` | 헤더 위치 ('top', 'bottom') |
+| `calendarHeaderPosition` | `string` | `'top'` | 헤더 위치 (`top` or `bottom`) |
 | `calendarHeaderStyle` | `Object` | `{}` | 헤더 스타일 |
 
 ##### 스타일링

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`innerStyle`**               | Style for the responsively sized inner view. This is necessary to account for padding/margin from the top level view. The inner view has style `flex:1` by default. If this component is nested within another dynamically sized container, remove the flex style by passing in `[]`. | Any    |
 | **`calendarHeaderStyle`**      | Style for the header text of the calendar                                                                                                  | Any            |
 | **`calendarHeaderContainerStyle`** | Style for the header text wrapper of the calendar                                                                                      | Any            |
-| **`calendarHeaderPosition`**   | Position of the header text (above or below)                                                                                               | `above, below` | **`above`** |
+| **`calendarHeaderPosition`**   | Position of the header text (`top` or `bottom`)                                                                                               | `top, bottom` | **`top`** |
 | **`calendarHeaderFormat`**     | Format for the header text of the calendar. For options, refer to [dayjs documentation](https://day.js.org/docs/en/display/format)    | String         |
 | **`dateNameStyle`**            | Style for the name of the day on work days in dates strip                                                                                  | Any            |
 | **`dateNumberStyle`**          | Style for the number of the day on work days in dates strip.                                                                               | Any            |

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,7 +178,7 @@ export interface CalendarStripProps {
   /**
    * Position of the calendar header
    */
-  calendarHeaderPosition?: "left" | "center" | "right";
+  calendarHeaderPosition?: "top" | "bottom";
   
   /**
    * Style for the calendar header


### PR DESCRIPTION
## Summary
- document correct values for `calendarHeaderPosition`
- keep API docs synced with README
- update TypeScript definition

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*


------
https://chatgpt.com/codex/tasks/task_b_6886e50426388322a95356271fcd8f76