### PR TITLE
Document updateMonthYear prop

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -73,7 +73,7 @@ yarn add atflee_react-native-calendar-strip
 | `onDateSelected` | `Function` | `undefined` | 날짜 선택 시 호출되는 콜백: `(date) => void` |
 | `onWeekChanged` | `Function` | `undefined` | 주 변경 시 호출되는 콜백: `(start: Dayjs, end: Dayjs) => void` |
 | `onHeaderSelected` | `Function` | `undefined` | 헤더 선택 시 호출되는 콜백: `() => void` |
-| `updateMonthYear` | `Function` | `undefined` | 표시되는 월/연도 업데이트 시 호출되는 콜백: `(month, year) => void` (`month`: `MM`, `year`: `YYYY`) |
+| `updateMonthYear` | `Function` | `undefined` | 현재 보이는 월/연도가 변경될 때 호출되는 콜백. `(month, year)` 문자열을 전달합니다 (`month`: `MM`, `year`: `YYYY`). |
 
 ##### 커스텀 컴포넌트
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`onWeekScrollEnd`**| Function to be used as a callback in `scrollable` mode when dates page stops gliding. Receives params `(start, end)` dayjs dates.                                 | Function |
 | **`onHeaderSelected`**| Function to be used as a callback when the header is selected. Receives param object `{weekStartDate, weekEndDate}` dayjs dates.                                 | Function |
 | **`headerText`**     | Text to use in the header. Use with `onWeekChanged` to receive the visible start & end dates.                                                                      | String  |
+| **`updateMonthYear`** | Callback fired when the visible month or year changes. Receives `(month, year)` strings. | Function |
 | **`updateWeek`**     | Update the week view if other props change. If `false`, the week view won't change when other props change, but will still respond to left/right selectors.        | Bool     | **`True`** |
 | **`useIsoWeekday`**  | start week on ISO day of week (default true). If false, starts week on _startingDate_ parameter.                                                                   | Bool     | **`True`** |
 | **`minDate`**        | minimum date that the calendar may navigate to. A week is allowed if minDate falls within the current week.                                                        | Any      |

--- a/index.d.ts
+++ b/index.d.ts
@@ -279,7 +279,8 @@ export interface CalendarStripProps {
   onHeaderSelected?: () => void;
   
   /**
-   * Callback to update month/year in parent component
+   * Called when the visible month or year changes.
+   * Allows parent components to track the current view.
    * @param month Two-digit month string ('MM')
    * @param year Four-digit year string ('YYYY')
    */


### PR DESCRIPTION
## Summary
- describe `updateMonthYear` callback in README and API docs
- add doc comment in TypeScript definitions

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_6886e5040684832284a9b7cb574736df