### PR TITLE
Add FlashList estimatedItemSize prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $ yarn add react-native-calendar-strip
 
 ### Scrollable CalendarStrip — New in 2.x
 
-The `scrollable` prop was introduced in 2.0.0 and features a bi-directional infinite scroller.  By default it uses React Native's [FlatList](https://reactnative.dev/docs/flatlist) to recycle days.  For long ranges you can enable [`useFlashList`](#props) to use [FlashList](https://github.com/Shopify/flash-list) instead.  The Chrome debugger can cause issues with this updating due to a [RN setTimeout bug](https://github.com/facebook/react-native/issues/4470). To prevent date shifts at the ends of the scroller, set the `minDate` and `maxDate` range to a year or less.
+The `scrollable` prop was introduced in 2.0.0 and features a bi-directional infinite scroller.  By default it uses React Native's [FlatList](https://reactnative.dev/docs/flatlist) to recycle days.  For long ranges you can enable [`useFlashList`](#props) to use [FlashList](https://github.com/Shopify/flash-list) instead. When using FlashList you may provide `flashListEstimatedItemSize` to avoid warnings. The Chrome debugger can cause issues with this updating due to a [RN setTimeout bug](https://github.com/facebook/react-native/issues/4470). To prevent date shifts at the ends of the scroller, set the `minDate` and `maxDate` range to a year or less.
 
 The refactor to support `scrollable` introduced internal changes to the `CalendarDay` component.  Users of the `dayComponent` prop may need to adjust their custom day component to accommodate the props passed to it.
 
@@ -333,6 +333,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`scrollerPaging`** | Dates are scrollable as a page (7 days) if true (Only works with `scrollable` set to true). | Bool     | **`True`** |
 | **`weekBuffer`**     | Number of weeks kept in memory when scrollable. The visible week plus this many weeks before and after will be rendered. Works with custom `numDaysInWeek`. Weeks are cached internally so raising this value has minimal performance impact. | Number | **`3`** |
 | **`useFlashList`**   | Use FlashList instead of FlatList for large buffers. Requires `@shopify/flash-list` dependency. | Bool | **`False`** |
+| **`flashListEstimatedItemSize`** | Estimated item size passed to FlashList when `useFlashList` is enabled. | Number | |
 | **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.  | Any      |
 | **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `dayjs` so it accepts both `Date` and `dayjs Date`.                                            | Any      |
 | **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` dayjs date.                                                                      | Function |

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,12 @@ export interface CalendarStripProps {
    * @default false
    */
   useFlashList?: boolean;
+
+  /**
+   * Estimated item size to pass to FlashList.
+   * Helps avoid warnings when using FlashList.
+   */
+  flashListEstimatedItemSize?: number;
   
   // Header configuration
   /**

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -48,6 +48,7 @@ const CalendarStrip = ({
   scrollerPaging,
   weekBuffer = 3,
   useFlashList = false,
+  flashListEstimatedItemSize,
   
   // Header configuration
   showMonth,
@@ -600,6 +601,9 @@ const CalendarStrip = ({
             onScrollEndDrag={onScrollEnd}
             viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs.current}
             initialScrollIndex={CENTER_INDEX}
+            {...(useFlashList && flashListEstimatedItemSize
+              ? { estimatedItemSize: flashListEstimatedItemSize }
+              : {})}
           />
         ) : (
           <View style={[styles.week, { width: contentWidth }]}>
@@ -683,6 +687,7 @@ CalendarStrip.propTypes = {
   scrollerPaging: PropTypes.bool,
   weekBuffer: PropTypes.number,
   useFlashList: PropTypes.bool,
+  flashListEstimatedItemSize: PropTypes.number,
 
   // Header configuration
   showMonth: PropTypes.bool,
@@ -755,6 +760,7 @@ CalendarStrip.defaultProps = {
   scrollerPaging: true,
   weekBuffer: 3,
   useFlashList: false,
+  flashListEstimatedItemSize: undefined,
 
   // Header configuration defaults
   showMonth: true,


### PR DESCRIPTION
## Summary
- support `flashListEstimatedItemSize` prop in CalendarStrip
- document new prop in README
- add TypeScript typings for the new prop

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_6886e50237408322ad6bf368b19ff234