### PR TITLE
Fix active date update without extraData

### DIFF
--- a/src/ActiveDateContext.js
+++ b/src/ActiveDateContext.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+// Context used to broadcast the current active date to all CalendarDateItem
+// components without relying on FlatList extraData updates.
+const ActiveDateContext = React.createContext(null);
+
+export default ActiveDateContext;

--- a/src/components/CalendarDateItem.js
+++ b/src/components/CalendarDateItem.js
@@ -1,7 +1,8 @@
-import React, { memo } from 'react';
+import React, { memo, useContext } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
+import ActiveDateContext from '../ActiveDateContext';
 
 /**
  * CalendarDateItem component
@@ -12,7 +13,6 @@ const CalendarDateItem = memo(({
   date,
   dateNumber,
   dayName,
-  isActive,
   isToday,
   isWeekend,
   showDayName,
@@ -32,12 +32,13 @@ const CalendarDateItem = memo(({
   markedDatesStyle,
   markerComponent,
   dayContainerStyle,
-  activeDate,
   highlightColor,
   calendarColor,
   styleWeekend,
   isDisabled
 }) => {
+  const contextActiveDate = useContext(ActiveDateContext);
+  const active = dayjs(date).isSame(dayjs(contextActiveDate), 'day');
   // Generate accessibility label for the date
   const accessibilityLabel = dayjs(date).format('dddd, MMMM D, YYYY');
   
@@ -59,26 +60,26 @@ const CalendarDateItem = memo(({
   // Determine styles based on active/today state
   const containerStyle = [
     styles.dateContainer,
-    isActive ? {
+    active ? {
       backgroundColor: highlightColor || styles.activeDate.backgroundColor
     } : null,
     dayContainerStyle,
-    calendarColor ? { backgroundColor: isActive ? highlightColor : calendarColor } : null
+    calendarColor ? { backgroundColor: active ? highlightColor : calendarColor } : null
   ];
   
   const dayStyle = [
     styles.dayText,
     dateNameStyle,
-    isActive ? highlightDateNameStyle : null,
-    isStyledWeekend && !isActive ? { color: '#999' } : null,
+    active ? highlightDateNameStyle : null,
+    isStyledWeekend && !active ? { color: '#999' } : null,
     isDisabled ? { opacity: disabledDateOpacity } : null
   ];
   
   const dateStyle = [
     styles.dateText,
     dateNumberStyle,
-    isActive ? highlightDateNumberStyle : null,
-    isStyledWeekend && !isActive ? { color: '#999' } : null,
+    active ? highlightDateNumberStyle : null,
+    isStyledWeekend && !active ? { color: '#999' } : null,
     isDisabled ? { opacity: disabledDateOpacity } : null
   ];
   
@@ -86,7 +87,7 @@ const CalendarDateItem = memo(({
   if (dayComponent) {
     return dayComponent({
       date,
-      isActive,
+      isActive: active,
       isToday,
       isWeekend,
       isDisabled,
@@ -200,7 +201,6 @@ CalendarDateItem.propTypes = {
   date: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.object]).isRequired,
   dateNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   dayName: PropTypes.string.isRequired,
-  isActive: PropTypes.bool,
   isToday: PropTypes.bool,
   isWeekend: PropTypes.bool,
   showDayName: PropTypes.bool,
@@ -221,7 +221,6 @@ CalendarDateItem.propTypes = {
   markedDatesStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   markerComponent: PropTypes.func,
   dayContainerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  activeDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.object]),
   highlightColor: PropTypes.string,
   calendarColor: PropTypes.string,
   styleWeekend: PropTypes.bool,
@@ -229,7 +228,6 @@ CalendarDateItem.propTypes = {
 };
 
 CalendarDateItem.defaultProps = {
-  isActive: false,
   isToday: false,
   isWeekend: false,
   showDayName: true,

--- a/src/components/CalendarStrip.js
+++ b/src/components/CalendarStrip.js
@@ -28,6 +28,7 @@ dayjs.extend(isoWeek);
 import CalendarHeader from '../CalendarHeader';
 import CalendarDateItem from './CalendarDateItem';
 import logger from '../utils/logger';
+import ActiveDateContext from '../ActiveDateContext';
 
 // Enable LayoutAnimation on Android
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -695,7 +696,6 @@ const CalendarStrip = forwardRef(function CalendarStrip({
             dateNumber={day.dayOfMonth}
             dayName={upperCaseDays ? day.dayNameUpper : day.dayName}
             isToday={day.isToday}
-            isActive={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
             isWeekend={day.dayOfWeek === 0 || day.dayOfWeek === 6}
             isCurrentMonth={day.isCurrentMonth}
             onDateSelected={() => handleDateSelection(day.date)}
@@ -755,6 +755,7 @@ const CalendarStrip = forwardRef(function CalendarStrip({
   const log = (__DEV__ && debug) ? logger.debug : () => {};
 
   return (
+    <ActiveDateContext.Provider value={activeDate}>
     <View style={[styles.container, style]} onLayout={onLayout}>
       <View style={[styles.inner, innerStyle]}>
         {showMonth && (
@@ -808,7 +809,6 @@ const CalendarStrip = forwardRef(function CalendarStrip({
                 dateNumber={day.dayOfMonth}
                 dayName={upperCaseDays ? day.dayNameUpper : day.dayName}
                 isToday={day.isToday}
-                isActive={dayjs(day.date).isSame(dayjs(activeDate), 'day')}
                 isWeekend={day.dayOfWeek === 0 || day.dayOfWeek === 6}
                 isCurrentMonth={day.isCurrentMonth}
                 onDateSelected={() => handleDateSelection(day.date)}
@@ -836,7 +836,9 @@ const CalendarStrip = forwardRef(function CalendarStrip({
         <View onLayout={onRightLayout}>{rightSelector}</View>
       </View>
     </View>
-  </View>
+    </View>
+    </View>
+    </ActiveDateContext.Provider>
   );
 });
 


### PR DESCRIPTION
## Summary
- add ActiveDateContext for broadcast of active date
- use the context inside `CalendarDateItem`
- wrap CalendarStrip contents with the provider

## Testing
- `npm test` *(fails: Cannot find package '@babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68885b661a548322b818defca58dfbd8